### PR TITLE
Customize homepage to display information about the VM configuration and current usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-"pucas @ git+https://github.com/Princeton-CDH/django-pucas.git@release/0.9"
+  "pucas @ git+https://github.com/Princeton-CDH/django-pucas.git@release/0.9",
 # "pucas>=0.9",  # after next release
+  "psutil"
 ]
 
 [project.urls]

--- a/src/htr2hpc/context_processors.py
+++ b/src/htr2hpc/context_processors.py
@@ -2,6 +2,7 @@ from os import cpu_count, getloadavg
 from socket import gethostname
 
 import psutil
+from django.template.defaultfilters import filesizeformat
 
 
 # Get host and CPU count once on load, since changing these requires a reboot
@@ -20,15 +21,22 @@ def vm_status(request):
 
     # load average returns average load over last 1, 5, and 15 minutes
     load_average = getloadavg()
+    # system memory usage: total, available, percent, etc
+    system_memory = psutil.virtual_memory()
+
     return {
-        "cpu_count": CPU_COUNT,
-        "load_average": {
-            "1": load_average[0],
-            "5": load_average[1],
-            "15": load_average[2],
+        "vm_status": {
+            # use to track if we're switching between VMs or if nginx+ is sticky
+            "hostname": HOSTNAME,
+            "cpu_count": CPU_COUNT,
+            "load_average": {
+                "1": load_average[0],
+                "5": load_average[1],
+                "15": load_average[2],
+            },
+            "total_memory": filesizeformat(system_memory.total),
+            "available_memory": filesizeformat(system_memory.available),
+            "used_memory": system_memory.percent,
         },
-        # use to track if we're switching between VMs or if nginx+ is sticky
-        "hostname": HOSTNAME,
-        # system memory usage: total, available, percent, etc
-        "system_memory": psutil.virtual_memory(),
+        "system_memory": system_memory,
     }

--- a/src/htr2hpc/context_processors.py
+++ b/src/htr2hpc/context_processors.py
@@ -1,0 +1,34 @@
+from os import cpu_count, getloadavg
+from socket import gethostname
+
+import psutil
+
+
+# Get host and CPU count once on load, since changing these requires a reboot
+
+#: number of logical CPUs in the system
+CPU_COUNT = cpu_count()
+#: hostname for the local VM
+HOSTNAME = gethostname()
+
+# os.uname potentially useful information (release, version, hardware)
+
+
+def vm_status(request):
+    """Custom context processor to return information about VM
+    configuration and resources."""
+
+    # load average returns average load over last 1, 5, and 15 minutes
+    load_average = getloadavg()
+    return {
+        "cpu_count": CPU_COUNT,
+        "load_average": {
+            "1": load_average[0],
+            "5": load_average[1],
+            "15": load_average[2],
+        },
+        # use to track if we're switching between VMs or if nginx+ is sticky
+        "hostname": HOSTNAME,
+        # system memory usage: total, available, percent, etc
+        "system_memory": psutil.virtual_memory(),
+    }

--- a/src/htr2hpc/settings.py
+++ b/src/htr2hpc/settings.py
@@ -43,3 +43,11 @@ TEMPLATES[0]["DIRS"].insert(0, HTR2HPC_INSTALL_DIR / "templates")
 # in which case custom templates would be picked up via app dirs;
 # But to override escriptorium templates, we need to treat it as a
 # template directory and put it first in the list.
+
+# add custom context processor to display VM status
+TEMPLATES[0]["OPTIONS"]["context_processors"].append(
+    "htr2hpc.context_processors.vm_status"
+)
+
+
+CUSTOM_HOME = True

--- a/src/htr2hpc/templates/additional_footer.html
+++ b/src/htr2hpc/templates/additional_footer.html
@@ -2,28 +2,18 @@
 <div class="row">
     <div class="col-12">
         <hr/>
-         <div hidden="" id="internal_stats">{
-         "hostname": "{{ hostname }}", 
-         "cpus": "{{ cpu_count }}", 
-         "load_average": {
-         {% for minutes, average in load_average.items %}
-                "{{ minutes }}": "{{ average }}"
-         {% endfor %}
-         },
-         "total_memory": "{{ system_memory.total|filesizeformat }}",
-         "available_memory": "{{ system_memory.available|filesizeformat }}",
-         "used_memory": "{{ system_memory.percent }}" }</div>
-        <h4>VM status ({{ hostname }})</h4>
+        {{ vm_status|json_script:"vm-stats" }}
+        <h4>VM status ({{ vm_status.hostname }})</h4>
     </div>
     <div class="col-4">
         <ul class="list-unstyled">
-            <li><b>CPUs:</b> {{ cpu_count }}</li>
+            <li><b>CPUs:</b> {{ vm_status.cpu_count }}</li>
         </ul>
     </div>
     <div class="col-4">
         <h5>Average load</h5>
         <ul class="list-unstyled">
-            {% for minutes, average in load_average.items %}
+            {% for minutes, average in vm_status.load_average.items %}
                 <li>{{ average|floatformat:3 }} ({{ minutes }} minute{{ minutes|pluralize }})</li>
             {% endfor %}
         </ul>

--- a/src/htr2hpc/templates/additional_footer.html
+++ b/src/htr2hpc/templates/additional_footer.html
@@ -1,0 +1,28 @@
+
+<div class="row">
+    <div class="col-12">
+        <hr/>
+        <h4>VM status ({{ hostname }})</h4>
+    </div>
+    <div class="col-4">
+        <ul class="list-unstyled">
+            <li><b>CPUs:</b> {{ cpu_count }}</li>
+        </ul>
+    </div>
+    <div class="col-4">
+        <h5>Average load</h5>
+        <ul class="list-unstyled">
+            {% for minutes, average in load_average.items %}
+                <li>{{ average|floatformat:3 }} ({{ minutes }} minute{{ minutes|pluralize }})</li>
+            {% endfor %}
+        </ul>
+    </div>
+    <div class="col-4">
+        <h5>Memory</h5>
+        <ul class="list-unstyled">
+            <li><b>total:</b> {{ system_memory.total|filesizeformat }}</li>
+            <li><b>available:</b> {{ system_memory.available|filesizeformat }}</li>
+            <li><b>percent used:</b> {{ system_memory.percent }}%</li>
+    </ul>
+    </div>
+</div>

--- a/src/htr2hpc/templates/additional_footer.html
+++ b/src/htr2hpc/templates/additional_footer.html
@@ -2,6 +2,17 @@
 <div class="row">
     <div class="col-12">
         <hr/>
+         <div hidden="" id="internal_stats">{
+         "hostname": "{{ hostname }}", 
+         "cpus": "{{ cpu_count }}", 
+         "load_average": {
+         {% for minutes, average in load_average.items %}
+                "{{ minutes }}": "{{ average }}"
+         {% endfor %}
+         },
+         "total_memory": "{{ system_memory.total|filesizeformat }}",
+         "available_memory": "{{ system_memory.available|filesizeformat }}",
+         "used_memory": "{{ system_memory.percent }}" }</div>
         <h4>VM status ({{ hostname }})</h4>
     </div>
     <div class="col-4">

--- a/src/htr2hpc/templates/additional_heading.html
+++ b/src/htr2hpc/templates/additional_heading.html
@@ -1,0 +1,4 @@
+{# customize heading for homepage #}
+<h1 class="jumbotron-heading">eScriptorium</h1>
+<p class="lead text-muted">A project providing digital recognition of handwritten documents using machine learning techniques.</p>
+<p>This is a test eScriptorium instance for assessment and evaluation only.</p>

--- a/src/htr2hpc/templates/additional_icons.html
+++ b/src/htr2hpc/templates/additional_icons.html
@@ -1,0 +1,1 @@
+{# required by escriptorium when CUSTOM_HOME=True #}


### PR DESCRIPTION
These updates are intended to help with reporting and tracking the status / configuration of the VM (related to #11 ).

Changes include:
- custom context processor to provide details like cpu count, available/total memory, average load
- enable eScriptorium custom home page behavior and add the required templates
- display VM details from the context processor in the homepage footer

This is what it looks like running on my machine:

![Screenshot 2024-10-08 at 4 49 38 PM](https://github.com/user-attachments/assets/1641518c-d28c-41f7-8a1c-41c87e77533a)

I included the hostname because I thought it could help us tell if the load balancer "sticky" configuration is working or if it's possible/likely to switch between the two VMs during a session.

Questions/notes:
- Please suggest changes to the customized title template if you have thoughts now. (We can always adjust later)
- Are there more details that would be helpful to include?
- Should we come up with a one-line version of important statistics that we embed somewhere (maybe not visible) that can be easily grabbed for including in test reports? What information should be included?
