### PR TITLE
Upload segmentation models after segmentation training completes

### DIFF
--- a/src/htr2hpc/api_client.py
+++ b/src/htr2hpc/api_client.py
@@ -228,13 +228,21 @@ class eScriptoriumAPIClient:
         # on successful update, returns the model object
         return to_namedtuple("model", resp.json())
 
-    def model_create(self, model_file: pathlib.Path, model_name: str, job: str):
+    def model_create(
+        self,
+        model_file: pathlib.Path,
+        job: str,
+        model_name: Optional[str] = None,
+    ):
         """Add a new model to eScriptorium. Takes a model file, name, and job
         (Segment or Recognize)."""
         if job not in {"Segment", "Recognize"}:
             raise ValueError(f"{job} is not a valid model job name")
 
         api_url = "models/"
+        # if model name is unset, use filename stem
+        if model_name is None:
+            model_name = model_file.stem
 
         with open(model_file, "rb") as mfile:
             files = {"file": mfile}

--- a/src/htr2hpc/train/data.py
+++ b/src/htr2hpc/train/data.py
@@ -181,8 +181,14 @@ def upload_models(
     with the specified job type (Segment/Recognize). Returns a count of the
     number of models created."""
     uploaded = 0
+
+    # segtrain creates models based on modelname with _0, _1, _2 ... _49
+    # sort numerically on the latter portion of the name
+    modelfiles = sorted(
+        model_dir.glob("*.mlmodel"), key=lambda path: int(path.stem.split("_")[-1])
+    )
     for model_file in tqdm(
-        model_dir.glob("*.mlmodel"),
+        modelfiles,
         desc=f"Uploading {model_type} models",
         disable=not show_progress,
     ):

--- a/src/htr2hpc/train/data.py
+++ b/src/htr2hpc/train/data.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 import subprocess
 from collections import defaultdict
+from tqdm import tqdm
 
 from kraken.containers import BaselineLine, Region, Segmentation
 
@@ -171,6 +172,27 @@ def get_training_data(api, output_dir, document_id, part_ids=None):
 def get_best_model(model_dir: pathlib.Path) -> pathlib.Path | None:
     best = list(model_dir.glob("*_best.mlmodel"))
     return best[0] if best else None
+
+
+def upload_models(
+    api, model_dir: pathlib.Path, model_type: str, show_progress=True
+) -> int:
+    """Upload all model files in the specified model directory to eScriptorum
+    with the specified job type (Segment/Recognize). Returns a count of the
+    number of models created."""
+    uploaded = 0
+    for model_file in tqdm(
+        model_dir.glob("*.mlmodel"),
+        desc=f"Uploading {model_type} models",
+        disable=not show_progress,
+    ):
+        # NOTE: should have error handling here;
+        # what kinds of exceptions/errors might occur?
+        created = api.model_create(model_file, job=model_type)
+        if created:
+            uploaded += 1
+
+    return uploaded
 
 
 # use api.update_model with model id and pathlib.Path to model file


### PR DESCRIPTION
resolves #29 

to test on della, if you are already running an editable install of a local checkout of htr2hpc code:
```sh
git fetch
git co feature/upload-seg-models
```

Changes in this PR:
- api `model_create` will use model filename as basis for model name if name is not specified
- new method to upload all `*.mlmodel` files in a single directory to create new models in eScriptorium
- report how many models were uploaded
- parameter to control progress bar display (on by default)