### PR TITLE
Clean up training data and output

### DIFF
--- a/src/htr2hpc/api_client.py
+++ b/src/htr2hpc/api_client.py
@@ -17,6 +17,14 @@ from htr2hpc import __version__ as _version
 logger = logging.getLogger(__name__)
 
 
+class NotFound(Exception):
+    pass
+
+
+class NotAllowed(Exception):
+    pass
+
+
 @dataclass
 class ResultsList:
     """API list response."""
@@ -184,9 +192,11 @@ class eScriptoriumAPIClient:
         #     except AttributeError:
         #         print(resp.content)
         elif resp.status_code == requests.codes.not_found:
-            logger.error("Error: not found")
+            raise NotFound(f"404 Not Found error: {rqst_url}")
         elif resp.status_code == requests.codes.unauthorized:
-            logger.error("Error: not authorized")
+            raise NotAllowed(f"401 Not Authorized: {rqst_url}")
+        elif resp.status_code == requests.codes.forbidden:
+            raise NotAllowed(f"403 Forbiddden: {rqst_url}")
         else:
             # TODO: error handling / logging for other cases?
             # (useful for dev if nothing else...)

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -5,13 +5,15 @@ import sys
 import logging
 import pathlib
 import time
+from dataclasses import dataclass
 from shutil import rmtree
+from typing import Optional
 
 from intspan import intspan
 from kraken.kraken import SEGMENTATION_DEFAULT_MODEL, DEFAULT_MODEL
 from tqdm import tqdm
 
-from htr2hpc.api_client import eScriptoriumAPIClient
+from htr2hpc.api_client import eScriptoriumAPIClient, NotFound, NotAllowed
 from htr2hpc.train.data import get_training_data, get_model, upload_models
 from htr2hpc.train.slurm import segtrain, slurm_job_status, slurm_job_queue_status
 
@@ -26,6 +28,134 @@ default_model = {
     "segmentation": SEGMENTATION_DEFAULT_MODEL,
     "transcription": DEFAULT_MODEL,
 }
+
+
+@dataclass
+class TrainingManager:
+    base_url: str
+    api_token: str
+    work_dir: pathlib.Path
+    document_id: int
+    training_mode: str
+    model_name: str
+    num_workers: int
+    parts: Optional[intspan] = None
+    model_id: Optional[int] = None
+    existing_data: bool = False
+    show_progress: bool = True
+
+    def __post_init__(self):
+        # initialize api client
+        self.api = eScriptoriumAPIClient(self.base_url, self.api_token)
+
+        # store the path to original working directory before changing directory
+        self.orig_working_dir = pathlib.Path.cwd()
+
+    def training_prep(self):
+        # create necessary directories and download training data and model file
+
+        self.training_data_dir = self.work_dir / "parts"
+        if not self.existing_data:
+            self.training_data_dir.mkdir()
+        get_training_data(
+            self.api, self.training_data_dir, self.document_id, self.parts
+        )
+
+        # if model id is specified, download the model from escriptorium API,
+        # confirming that it is the appropriate type (segmentation/transcription)
+        # NOTE: currently ignores existing data flag, since we need model file name
+        if self.model_id:
+            self.model_file = get_model(
+                self.api,
+                self.model_id,
+                self.training_mode,
+                self.work_dir,
+            )
+        # if model id is not specified, use the default from kraken
+        else:
+            # get the appropriate model file for the requested training mode
+            # kraken default defs are path objects
+            self.model_file = default_model[args.mode]
+
+        # create a directory and path for the output model file
+        self.output_model_dir = self.work_dir / "output_model"
+        # remove the output model directory to avoid confusion with any old
+        # model files from a previous run
+        if self.existing_data:
+            rmtree(self.output_model_dir)
+        self.output_model_dir.mkdir()
+        self.output_modelfile = self.output_model_dir / self.model_name
+
+    def monitor_slurm_job(self, job_id):
+        # get initial job status (typically PENDING)
+        job_status = slurm_job_queue_status(job_id)
+        # typical states are PENDING, RUNNING, SUSPENDED, COMPLETING, and COMPLETED.
+        # https://slurm.schedmd.com/job_state_codes.html
+        # end states could be FAILED, CANCELLED, OUT_OF_MEMORY, TIMEOUT
+        # * but note that squeue only reports on pending & running jobs
+
+        # loop while the job is pending or running and then stop
+        # use tqdm to display job status and wait time
+        with tqdm(
+            desc=f"Slurm job {job_id}",
+            bar_format="{desc} | total time: {elapsed}{postfix} ",
+            disable=not args.show_progress,
+        ) as statusbar:
+            running = False
+            while job_status:
+                status = f"status: {job_status}"
+                # display an unofficial runtime to aid in troubleshooting
+                if running:
+                    runtime_elapsed = statusbar.format_interval(time.time() - runstart)
+                    status = f"{status}  ~ run time: {runtime_elapsed}"
+                statusbar.set_postfix_str(status)
+                time.sleep(1)
+                job_status = slurm_job_queue_status(job_id)
+                # capture start time first time we get a status of running
+                if not running and job_status == "RUNNING":
+                    running = True
+                    runstart = time.time()
+
+        # check the completed status
+        job_status = slurm_job_status(job_id)
+        print(
+            f"Job {job_id} is no longer queued; ending status: {','.join(job_status)}"
+        )
+        job_output = args.work_dir / f"segtrain_{job_id}.out"
+        print(f"Job output is in {job_output}")
+
+    def segmentation_training(self):
+        # get absolute versions of these paths _before_ changing working directory
+        abs_training_data_dir = self.training_data_dir.absolute()
+        abs_model_file = self.model_file.absolute()
+        abs_output_modelfile = self.output_modelfile.absolute()
+
+        # change directory to working directory, since by default,
+        # slurm executes the job from the directory where it was submitted
+        os.chdir(self.work_dir)
+
+        job_id = segtrain(
+            abs_training_data_dir,
+            abs_model_file,
+            abs_output_modelfile,
+            self.num_workers,
+        )
+        self.monitor_slurm_job(job_id)
+        # change back to original working directory
+        os.chdir(self.orig_working_dir)
+        self.upload_models()
+
+    def upload_models(self):
+        # - for segmentation, upload all models to eScriptorium as new models
+        upload_count = upload_models(
+            self.api,
+            self.output_modelfile.parent,
+            self.training_mode,
+            show_progress=self.show_progress,
+        )
+        # - should this behavior depend on job exit status?
+        # reasonable to assume any model files created should be uploaded?
+        print(f"Uploaded {upload_count} {self.training_mode} models to eScriptorium")
 
 
 def main():
@@ -165,113 +295,27 @@ def main():
     logger_upscope = logging.getLogger("htr2hpc")
     logger_upscope.setLevel(logging.INFO)
 
-    api = eScriptoriumAPIClient(args.base_url, api_token=api_token)
-
     # TODO : check api access works before going too far?
     # (currently does not handle connection error gracefully)
 
-    training_data_dir = args.work_dir / "parts"
-    if not args.existing_data:
-        training_data_dir.mkdir()
-        get_training_data(api, training_data_dir, args.document_id, args.parts)
+    # nearly all the argparse options need to be passed to the training manager class
+    # convert to a _copy_ dictionary and delete the unused parmeters
+    arg_options = dict(vars(args))
+    del arg_options["mode"]
+    del arg_options["clean"]
 
-    # if model id is specified, download the model from escriptorium API,
-    # confirming that it is the appropriate type (segmentation/transcription)
-    # NOTE: currently ignores existing data flag, since we need model file name
-    if args.model_id:
-        model_file = get_model(
-            api,
-            args.model_id,
-            es_model_jobs[args.mode],
-            args.work_dir,
-        )
+    # initialize training manager
+    training_mgr = TrainingManager(
+        api_token=api_token, training_mode=es_model_jobs[args.mode], **arg_options
+    )
+    try:
+        # prep data for training
+        training_mgr.training_prep()
 
-    # if model id is not specified, use the default from kraken
-    else:
-        # get the appropriate model file for the requested training mode
-        # kraken default defs are path objects
-        model_file = default_model[args.mode]
-
-    # create a directory and path for the output model file
-    output_model_dir = args.work_dir / "output_model"
-    # remove the output model directory to avoid confusion with any old
-    # model files from a previous run
-    if args.existing_data:
-        rmtree(output_model_dir)
-    output_model_dir.mkdir()
-    output_modelfile = output_model_dir / args.model_name
-
-    # get absolute versions of these paths _before_ changing working directory
-    abs_training_data_dir = training_data_dir.absolute()
-    abs_model_file = model_file.absolute()
-    abs_output_modelfile = output_modelfile.absolute()
-
-    # store the path to original working directory before changing directory
-    orig_working_dir = pathlib.Path.cwd()
-
-    # change directory to working directory, since by default,
-    # slurm executes the job from the directory where it was submitted
-    os.chdir(args.work_dir)
-
-    if args.mode == "segmentation":
-        job_id = segtrain(
-            abs_training_data_dir,
-            abs_model_file,
-            abs_output_modelfile,
-            args.num_workers,
-        )
-        # get job status (presumably PENDING)
-        job_status = slurm_job_queue_status(job_id)
-        # typical states are PENDING, RUNNING, SUSPENDED, COMPLETING, and COMPLETED.
-        # https://slurm.schedmd.com/job_state_codes.html
-        # end states could be FAILED, CANCELLED, OUT_OF_MEMORY, TIMEOUT
-        # * but note that squeue only reports on pending & running jobs
-
-        # loop while the job is pending or running and then stop
-        # use tqdm to display job status and wait time
-        with tqdm(
-            desc=f"Slurm job {job_id}",
-            bar_format="{desc} | total time: {elapsed}{postfix} ",
-            disable=not args.show_progress,
-        ) as statusbar:
-            running = False
-            while job_status:
-                status = f"status: {job_status}"
-                # display an unofficial runtime to aid in troubleshooting
-                if running:
-                    runtime_elapsed = statusbar.format_interval(time.time() - runstart)
-                    status = f"{status}  ~ run time: {runtime_elapsed}"
-                statusbar.set_postfix_str(status)
-                time.sleep(1)
-                job_status = slurm_job_queue_status(job_id)
-                # capture start time first time we get a status of running
-                if not running and job_status == "RUNNING":
-                    running = True
-                    runstart = time.time()
-
-        # check the completed status
-        job_status = slurm_job_status(job_id)
-        print(
-            f"Job {job_id} is no longer queued; ending status: {','.join(job_status)}"
-        )
-        job_output = args.work_dir / f"segtrain_{job_id}.out"
-        print(f"Job output should be in {job_output}")
-
-        # change back to original working directory
-        os.chdir(orig_working_dir)
-
-        # after run completes, check for results
-        # - for segmentation, upload all models to eScriptorium as new models
-        upload_count = upload_models(
-            api,
-            output_modelfile.parent,
-            es_model_jobs[args.mode],
-            show_progress=args.show_progress,
-        )
-        # - does this behavior depend on job exit status?
-        # reasonable to assume any model files created should be uploaded¿
-
-        print(f"Uploaded {upload_count} segmentation models to eScriptorium")
+        if args.mode == "segmentation":
+            training_mgr.segmentation_training()
+    except (NotFound, NotAllowed) as err:
+        print(f"Something went wrong: {err}")
 
     # TODO: handle transcription training
 


### PR DESCRIPTION
to address #30 

Adds a new boolean parameter `--clean` / `--no-clean` ; cleaning is on by default.

I've refactored the existing functionality into a new `TrainingManager` class to make it easier to catch errors during data prep/download and training so that clean up will still be done if it is not disabled (it looks like a lot of changes in the diff but mostly just moving code around).  My hope is that this will also make it easier to add support for recognition training. 

I've successfully tested this on della.