### PR TITLE
Django integration (preliminary)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
   "humanize",
   "simple_slurm",
   "tqdm",
-  "intspan"
+  "intspan",
+  "fabric"
 ]
 
 [project.urls]

--- a/src/htr2hpc/api_client.py
+++ b/src/htr2hpc/api_client.py
@@ -106,9 +106,39 @@ class Workflow:
     # to handle missing values
 
 
+@dataclass
+class OCRModel:
+    #: model id in escriptorium
+    pk: int
+    #: model name
+    name: str
+    #: url to model file
+    file: str
+    #: file size
+    file_size: int
+    #: training job (Segment or Recognize)
+    job: str
+    #: owner username
+    owner: str
+    #: boolean indicating whether or not this model is currently training
+    training: bool
+    #: list of versions
+    versions: list
+    #: list of related documents by document id
+    documents: list[int]
+    #: model accuracy
+    accuracy_percent: float
+    #: model permissions
+    rights: str
+    #: parent model if this model is finetuned from another model; not always supplied
+    parent: Optional[str] = None
+    #: whether model is sharable
+    can_share: bool
+
+
 # keep a registry of result classes for API result objects,
 # so they can be reused once they are defined
-RESULTCLASS_REGISTRY = {"task": Task, "workflow": Workflow}
+RESULTCLASS_REGISTRY = {"task": Task, "workflow": Workflow, "model": OCRModel}
 
 
 def to_namedtuple(name: str, data: Any):

--- a/src/htr2hpc/api_client.py
+++ b/src/htr2hpc/api_client.py
@@ -100,6 +100,7 @@ class Task:
 class Workflow:
     convert: Optional[str] = None
     segment: Optional[str] = None
+    transcribe: Optional[str] = None
     # workflow status is only present when a workflow has not run,
     # so define a dataclass and make them optional
     # to handle missing values

--- a/src/htr2hpc/api_client.py
+++ b/src/htr2hpc/api_client.py
@@ -130,10 +130,10 @@ class OCRModel:
     accuracy_percent: float
     #: model permissions
     rights: str
-    #: parent model if this model is finetuned from another model; not always supplied
-    parent: Optional[str] = None
     #: whether model is sharable
     can_share: bool
+    #: parent model if this model is finetuned from another model; not always supplied
+    parent: Optional[str] = None
 
 
 # keep a registry of result classes for API result objects,
@@ -197,8 +197,9 @@ class eScriptoriumAPIClient:
         expected_status: int = requests.codes.ok,
     ):
         """
-        Make a GET request with the configured session. Takes a url
-        relative to :attr:`api_root` and optional dictionary of parameters for the request.
+        Make an http request with the configured session. Takes a url
+        relative to or starting with :attr:`api_root` and optional dictionaries
+        of parameters, data, and files for the request.
         """
         rqst_url = f"{self.api_root}/{url}"
         rqst_opts = {}
@@ -221,7 +222,7 @@ class eScriptoriumAPIClient:
 
         resp = session_request(rqst_url, **rqst_opts)
         logger.debug(
-            f"get {rqst_url} {resp.status_code}: {resp.elapsed.total_seconds()} sec"
+            f"{method} {rqst_url} {resp.status_code}: {resp.elapsed.total_seconds()} sec"
         )
         if resp.status_code == expected_status:
             return resp

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -110,20 +110,21 @@ def segtrain(
     logger.debug(
         f"Connecting to {settings.HPC_HOSTNAME} as {username} with keyfile {settings.HPC_SSH_KEYFILE}"
     )
-    conn = Connection(
-        host=settings.HPC_HOSTNAME,
-        user=username,
-        connect_kwargs={"key_filename": settings.HPC_SSH_KEYFILE},
-    )
+
     user.notify("Starting remote training")
     # note: may need to use tmux to keep from disconnecting
     try:
-        with conn.cd(working_dir):
-            result = conn.run(
-                f"conda run -n htr2hpc {cmd}",
-                env={"ESCRIPTORIUM_API_TOKEN": api_token},
-            )
-            print(result)
+        with Connection(
+            host=settings.HPC_HOSTNAME,
+            user=username,
+            connect_kwargs={"key_filename": settings.HPC_SSH_KEYFILE},
+        ) as conn:
+            with conn.cd(working_dir):
+                result = conn.run(
+                    f"module load anaconda3/2024.6 && conda run -n htr2hpc {cmd}",
+                    env={"ESCRIPTORIUM_API_TOKEN": api_token},
+                )
+                print(result)
     except UnexpectedExit as err:
         print(err)
         # send training error event

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -90,7 +90,7 @@ def segtrain(
 
     arg_options = [
         f"--document {document_pk}",  # document id is always required
-        f"--model-name segtrain_doc{document_pk}",  # TODO: get from model
+        f"--model-name {model.name}",
         "--no-progress",  # disable progressbar
     ]
 

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -99,8 +99,15 @@ def segtrain(
     # for now just output the command
     logger.info(cmd)
 
-    # ideally hostname should be set in django config
-    conn = Connection(host="della", user=username)
+    # hostname and ssh key path set in django config
+    logger.debug(
+        f"Connecting to {settings.HPC_HOSTNAME} as {username} with keyfile {settings.HPC_SSH_KEYFILE}"
+    )
+    conn = Connection(
+        host=settings.HPC_HOSTNAME,
+        user=username,
+        connect_kwargs={"key_filename": settings.HPC_SSH_KEYFILE},
+    )
     # note: may need to use tmux to keep from disconnecting
     with conn.cd(working_dir):
         result = conn.run(

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -25,7 +25,7 @@ def segtrain(
     model_pk=None,
     part_pks=[],
     document_pk=None,
-    task_group_pk=None,
+    task_group_pk=None,  # do train/segtrain update task status anywhere?
     user_pk=None,
     **kwargs,
 ):
@@ -125,6 +125,9 @@ def segtrain(
                     env={"ESCRIPTORIUM_API_TOKEN": api_token},
                 )
                 print(result)
+        # TODO: maybe script can write job id to a  dot file in the output dir
+        # so the celery task can check the status?
+        # or do we even need that level of detail (pending/running/complete)
     except UnexpectedExit as err:
         print(err)
         # send training error event
@@ -143,7 +146,7 @@ def segtrain(
         )
         # escriptorium task deletes the model if there is an error
         # is it always safe to do that?
-        model.delete()
+        # model.delete()
         return
 
     # could the celery task exit? or does it need to monitor the

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -113,7 +113,7 @@ def segtrain(
 
     user.notify(
         "Starting remote training; slurm portion can be monitored on mydella",
-        links=["https://mydella.princeton.edu/pun/sys/dashboard/activejobs"],
+        links=[{'text': 'Della Active Jobs', 'src': "https://mydella.princeton.edu/pun/sys/dashboard/activejobs"}],
     )
     # note: may need to use tmux to keep from disconnecting
     try:

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -2,7 +2,8 @@ import logging
 
 from celery import shared_task
 from django.contrib.auth import get_user_model
-from django.contrib.sites.shortcuts import get_current_site
+from django.contrib.sites.models import Site
+from django.conf import settings
 from intspan import intspan
 
 logger = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ def segtrain(
     # create a name for an output directory based on mode and document id
     outdir = f"segtrain_doc{document_pk}"
 
-    site = get_current_site()
+    site = Site.objects.get(pk=settings.SITE_ID)
     site_url = site.domain
     if not site_url.startswith("http"):
         site_url = f"https://{site_url}"

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -111,7 +111,10 @@ def segtrain(
         f"Connecting to {settings.HPC_HOSTNAME} as {username} with keyfile {settings.HPC_SSH_KEYFILE}"
     )
 
-    user.notify("Starting remote training")
+    user.notify(
+        "Starting remote training; slurm portion can be monitored on mydella",
+        links=["https://mydella.princeton.edu/pun/sys/dashboard/activejobs"],
+    )
     # note: may need to use tmux to keep from disconnecting
     try:
         with Connection(

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -1,0 +1,74 @@
+import logging
+
+from celery import shared_task
+from django.contrib.auth import get_user_model
+from django.contrib.sites.shortcuts import get_current_site
+from intspan import intspan
+
+logger = logging.getLogger(__name__)
+
+# override escriptorium training tasks to run on HPC
+
+User = get_user_model()
+
+
+def override_tasks():
+    from escriptorium import celery
+
+    celery.app.tasks.unregister("core.tasks.segtrain")
+
+
+@shared_task(default_retry_delay=60 * 60)
+def segtrain(
+    model_pk=None,
+    part_pks=[],
+    document_pk=None,
+    task_group_pk=None,
+    user_pk=None,
+    **kwargs,
+):
+    print("### running override segtrain task")
+
+    # we require both of these; are they really optional?
+    if not user_pk or document_pk:
+        # can't proceeed
+        logger.error("segtrain called without document_pk or user_pk")
+        return
+
+    try:
+        user = User.objects.get(pk=user_pk)
+    except User.DoesNotExist:
+        # error / bail out
+        logger.error(f"segtrain called with invalid user_pk {user_pk}")
+        return
+
+    # do we need to mark the model as training?
+    # should that be done here or in the script via api?
+
+    # generate the command to run
+
+    # create a name for an output directory based on mode and document id
+    outdir = f"segtrain_doc{document_pk}"
+
+    site = get_current_site()
+    site_url = site.domain
+    if not site_url.startswith("http"):
+        site_url = f"https://{site_url}"
+
+    arg_options = [
+        f"--document {document_pk}",  # document id is always required
+        f"--model-name segtrain_doc{document_pk}",  # our script requires a model name
+    ]
+
+    # part and model are optional
+    if part_pks:
+        # parse and serialize with intspan since that's what we use on the other side
+        arg_options.append(f"--parts {intspan(part_pks)}")
+    if model_pk:
+        arg_options.append(f"--model {model_pk}")
+    opts = " ".join(arg_options)
+
+    cmd = f"htr2hpc-train segmentation {site_url} {outdir} {opts}"
+
+    # for now just output the command
+    logger.debug(cmd)

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -85,6 +85,7 @@ def segtrain(
     arg_options = [
         f"--document {document_pk}",  # document id is always required
         f"--model-name segtrain_doc{document_pk}",  # TODO: get from model
+        f"--no-progress",  # disable progressbar
     ]
 
     # part and model are optional
@@ -120,6 +121,10 @@ def segtrain(
     # remote script?
 
     # then what?
+
+
+# todo: maybe make the fab command a method that can be run for testing
+# from shell/cli ?
 
 
 @shared_task(default_retry_delay=60 * 60)

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -1,13 +1,13 @@
 import logging
 
 from celery import shared_task
+from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.conf import settings
 from intspan import intspan
 
-# import escriptorium models
-from apps.core.models import Transcription
+# imports from escriptorium
 from apps.users.consumers import send_event
 
 logger = logging.getLogger(__name__)
@@ -62,6 +62,7 @@ def segtrain(
     )
 
     # TODO: mark the model as training
+    # OcrModel = apps.get_model("core", "OcrModel")
     # would be nice if the script could handle, but that field is listed
     # as read only in the api
 
@@ -118,6 +119,8 @@ def train(
     outdir = f"train_transcription{transcription_pk}"
 
     # get document from transcription
+    Transcription = apps.get_model("core", "Transcription")
+    # OcrModel = apps.get_model("core", "OcrModel")
     transcription = Transcription.objects.get(pk=transcription_pk)
     document = transcription.document
 

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -72,8 +72,9 @@ def segtrain(
     api_token = user.auth_token.key
 
     # create a name for an output directory based on mode and document id
-    # TODO: make this relative to scratch & username?
     working_dir = f"/scratch/gpfs/{username}/htr2hpc"
+    # TODO: should we add a timestamp to ensure uniqueness?
+    # script will fail if there is an existing directory
     outdir = f"segtrain_doc{document_pk}"
 
     # generate the command to run

--- a/src/htr2hpc/tasks.py
+++ b/src/htr2hpc/tasks.py
@@ -29,10 +29,20 @@ def segtrain(
 ):
     print("### running override segtrain task")
 
+    # NOTE: when called from the web ui, the SegTrainForm includes
+    # a field for model_name but that value is not passed to the celery task
+    # HOWEVER: when a model name is specified, the form process method
+    # creates a new, empty model db record with that name; when override
+    # is not requested, form logic creates a copy of the model.
+    # So we may need to revise the script with an option to update
+    # the specified model.
+
     # we require both of these; are they really optional?
-    if not user_pk or document_pk:
-        # can't proceeed
-        logger.error("segtrain called without document_pk or user_pk")
+    if not all([user_pk, document_pk]):
+        # can't proceed without both of these
+        logger.error(
+            "segtrain called with out document_pk or user_pk (document_pk={document_pk} user_pk={user_pk}"
+        )
         return
 
     try:
@@ -71,4 +81,4 @@ def segtrain(
     cmd = f"htr2hpc-train segmentation {site_url} {outdir} {opts}"
 
     # for now just output the command
-    logger.debug(cmd)
+    logger.info(cmd)


### PR DESCRIPTION
towards #15 

This PR adds custom celery tasks for `train` and `segtrain` to be patched into escriptorium code as replacements for the built-in versions. 

I'm doing the patching with ansible; changes are included in this pr https://github.com/Princeton-CDH/cdh-ansible/pull/253
- I'm modifying the tasks.py file to rename the builtin `train` and `segtrain` methods to `es_train` and `es_segtrain` and importing my versions from `htr2hpc.tasks` so that anywhere in the escriptorium code where these tasks are imported, they get our htr2hpc versions instead.

I had to go digging into the escriptorium codebase to understand the context of where and how the celery task is called. They key logic for us to be aware of is in the form processing, here:
https://gitlab.com/scripta/escriptorium/-/blob/develop/app/apps/core/forms.py?ref_type=heads#L983-1006 
Basically no matter what you request in the UI, escriptorium sends in a model to be updated by the celery task, whether it's a brand new empty model, a cloned model (if you're fine-tuning), or an existing model (if update is selected). I think this means we need a flag to the htr2hpc-train script to tell it to update the model that is passed in. Based on the escriptorium task code, the kraken segmentation model object does have a notion of a best model. Let's discuss and make sure we agree on how to adjust the script.

I think the celery task needs to mark the model as "training" when starting and then not when completed. I was hoping this could be done from the API but it looks like it's marked as read only.   

I presume we should also match the messages that the escriptorium task does to notify the user of status.

Should we add a timestamp to the output directory to ensure uniqueness?  It may be more of a problem for dev when the script errors and doesn't clean up.

This only works for netid-based user accounts. What kind of error handling should we have if the remote connection fails?
