### PR TITLE
Add validation steps to skip broken imgs, null masks/baselines

### DIFF
--- a/src/htr2hpc/api_client.py
+++ b/src/htr2hpc/api_client.py
@@ -393,7 +393,11 @@ class eScriptoriumAPIClient:
         """details for one part of a document"""
         api_url = f"documents/{document_id}/parts/{part_id}/"
         resp = self._make_request(api_url)
-        return to_namedtuple("part", resp.json())
+        try:
+            return to_namedtuple("part", resp.json())
+        except Exception as e:
+            print(f"Error in part {part_id}: '{e}'. Skipping...")
+            return None
 
     def document_part_transcription_list(
         self, document_id: int, part_id: int, transcription_id: Optional[int] = None

--- a/src/htr2hpc/api_client.py
+++ b/src/htr2hpc/api_client.py
@@ -389,17 +389,6 @@ class eScriptoriumAPIClient:
         # document part listed here is different than full parts result
         return ResultsList(api=self, result_type="document_parts", **resp.json())
 
-    def document_part_validate(self, document_id: int, part_id: int):
-        """details for one part of a document"""
-        api_url = f"documents/{document_id}/parts/{part_id}/"
-        resp = self._make_request(api_url)
-            
-        try:
-            return to_namedtuple("part", resp.json())
-        except Exception as e:
-            print(f"Error in part {part_id}: '{e}'. Skipping...")
-            return None
-
     def document_part_details(self, document_id: int, part_id: int):
         """details for one part of a document"""
         api_url = f"documents/{document_id}/parts/{part_id}/"
@@ -416,10 +405,14 @@ class eScriptoriumAPIClient:
                valid_lines.append(line)
         # if there are any broken lines, update record with valid lines and report on skipped lines
         if broken_lines:
-           resp_json["lines"] = valid_lines
+            resp_json["lines"] = valid_lines
             logger.warn("Skipping {len(broken_lines)} lines due to missing mask or baseline: {','.join([line['pk'] for line in broken_lines])} (document {document_id}, part {part_id})")
             
-        return to_namedtuple("part", resp_json)
+        try:
+            return to_namedtuple("part", resp_json)
+        except Exception as e:
+            print(f"Error in part {part_id}: '{e}'. Skipping...")
+            return None
 
     def document_part_transcription_list(
         self, document_id: int, part_id: int, transcription_id: Optional[int] = None

--- a/src/htr2hpc/api_client.py
+++ b/src/htr2hpc/api_client.py
@@ -407,13 +407,17 @@ class eScriptoriumAPIClient:
         
         # skip lines with missing baseline or mask coords
         broken_lines = []
+        valid_lines = []
         resp_json = resp.json()
-        for i, line in enumerate(resp_json["lines"]):
+        for line in resp_json["lines"]:
             if line["mask"] == None or line["baseline"] == None:
-                print(f"Warning: line {line['pk']} is missing a mask or baseline. Skipping...")
-                broken_lines.append(i)
-        for i in broken_lines:
-            resp_json["lines"].pop(i)
+                broken_lines.append(line)
+            else:
+               valid_lines.append(line)
+        # if there are any broken lines, update record with valid lines and report on skipped lines
+        if broken_lines:
+           resp_json["lines"] = valid_lines
+            logger.warn("Skipping {len(broken_lines)} lines due to missing mask or baseline: {','.join([line['pk'] for line in broken_lines])} (document {document_id}, part {part_id})")
             
         return to_namedtuple("part", resp_json)
 

--- a/src/htr2hpc/train/data.py
+++ b/src/htr2hpc/train/data.py
@@ -64,6 +64,8 @@ def get_segmentation_data(
     # same for block types (used for regions)
     block_types = {btype.pk: btype.name for btype in document_details.valid_block_types}
     part = api.document_part_details(document_id, part_id)
+    if not part:
+        return ( None, None )
 
     # adapted from escriptorium.app.core.tasks.make_segmentation_training_data
     # and  make_recognition_segmentation
@@ -230,6 +232,10 @@ def get_training_data(
         )
         for part_id in part_ids
     ]
+    # if any parts are broken, get_segmentation_data should return None, None.
+    # filter these out.
+    segmentation_data = [d for d in segmentation_data if d != (None, None)]
+    
     # get counts of data for reporting and scaling slurm request
     counts = TrainingDataCounts(parts=len(segmentation_data))
     # segmentation data is a list of tuples of segment, part

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -98,7 +98,7 @@ class TrainingManager:
     def training_validate(self):
         broken = []
         for part_id in self.parts:
-            part = self.api.document_part_details(self.document_id, part_id)
+            part = self.api.document_part_validate(self.document_id, part_id)
             if part == None:
                 broken.append(part_id)
         for part_id in broken:

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -95,6 +95,15 @@ class TrainingManager:
         # store the path to original working directory before changing directory
         self.orig_working_dir = pathlib.Path.cwd()
 
+    def training_validate(self):
+        broken = []
+        for part_id in self.parts:
+            part = self.api.document_part_details(self.document_id, part_id)
+            if part == None:
+                broken.append(part_id)
+        for part_id in broken:
+            self.parts.remove(part_id)
+
     def training_prep(self):
         # create necessary directories and download training data and model file
 
@@ -505,6 +514,8 @@ def main():
         sys.exit(1)
 
     try:
+        # validate data for training
+        training_mgr.training_validate()
         # prep data for training
         training_mgr.training_prep()
         # run training for requested mode

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -95,15 +95,6 @@ class TrainingManager:
         # store the path to original working directory before changing directory
         self.orig_working_dir = pathlib.Path.cwd()
 
-    def training_validate(self):
-        broken = []
-        for part_id in self.parts:
-            part = self.api.document_part_validate(self.document_id, part_id)
-            if part == None:
-                broken.append(part_id)
-        for part_id in broken:
-            self.parts.remove(part_id)
-
     def training_prep(self):
         # create necessary directories and download training data and model file
 
@@ -514,8 +505,6 @@ def main():
         sys.exit(1)
 
     try:
-        # validate data for training
-        training_mgr.training_validate()
         # prep data for training
         training_mgr.training_prep()
         # run training for requested mode


### PR DESCRIPTION
While importing and experimenting with training on various existing ground truth datasets, I encountered an error that occurs when the ground truth import accidentally creates a part with a broken image. You can see an example in [image 133 of doc 47](https://test-htr.lib.princeton.edu/document/47/images/?select=64529).

I think this issue will be rare (this is my first time encountering it), but to prevent the htr2hpc script from erroring out when it hits such a broken image I have added a validate ground truth step that first checks whether there are any issues getting the data from each of the parts. If a part does have an error, that part pk is removed from the intspan of the parts to be passed forward to the `training_mgr.training_prep()` step.

The error had been:

```
│ /scratch/gpfs/croughan/repos/htr2hpc/src/htr2hpc/api_client.py:158 in │
│ to_namedtuple │
│ │
│ 155 │ │ │ nt_class = namedtuple(name, data) │
│ 156 │ │ │ RESULTCLASS_REGISTRY[name] = nt_class │
│ 157 │ │ # once we have the class, initialize an instance with the give │
│ ❱ 158 │ │ return nt_class( │
│ 159 │ │ │ # convert any nested objects to namedtuple classes │
│ 160 │ │ │ # use key name as namedtuple class name; convert plurals t │
│ 161 │ │ │ # NOTE: could add aliases other cleanup, e.g. shared_with_ │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: thumbnail.__new__() missing 2 required positional arguments: 'card'
and 'large'
```

This is because the API result for the part with the broken image is the following:

```
{
            "pk": 64529,
            "name": "",
            "filename": "._MS B Vetala 6414-0008.jpg",
            "title": "Element 133",
            "typology": null,
            "image": {
                "uri": "/media/documents/47/._MS_B_Vetala_6414-0008.jpg",
                "size": [
                    null,
                    null
                ],
                "thumbnails": {}
            },
            "image_file_size": 213,
            "original_filename": "._MS B Vetala 6414-0008.jpg",
            "workflow": {
                "convert": "done"
            },
            "order": 132,
            "recoverable": false,
            "transcription_progress": 0,
            "source": "zip//Archive_tD40I8j.zip/._MS B Vetala 6414-0008.jpg",
            "max_avg_confidence": null,
            "comments": null,
            "updated_at": "2025-02-14T22:39:44.242884Z"
        },
```