### PR TITLE
Revise script for dynamic resource selection

### DIFF
--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -31,7 +31,10 @@ def slurm_get_avg_epoch(slurm_output):
     if epoch_times:
         epoch_times = [datetime.datetime.strptime(t, '%H:%M:%S') for t in epoch_times]
         epoch_times = [datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second).seconds for t in epoch_times]
-        return math.ceil(sum(epoch_times) / len(epoch_times))
+        epoch_avg = math.ceil(sum(epoch_times) / len(epoch_times))
+        if epoch_avg == 0:
+            epoch_avg = 1
+        return epoch_avg
     
 
 def stats_get_max_cpu(job_stats):
@@ -69,7 +72,7 @@ def calc_full_duration(slurm_output, job_stats):
             
             return epoch_request, datetime.timedelta(minutes=math.ceil((setup_time + ( epoch_avg * epoch_time_est * 1.1 )) / 60))
     
-        elif job_duration > datetime.timedelta(minutes=14):
+        elif datetime.timedelta(seconds=job_duration) > datetime.timedelta(minutes=14):
             # if epoch_avg returns as None (no epochs completed during the first train task),
             # but job did not error out early, assume that more time is needed per epoch.
             # assume 15min per epoch and 15min setup time.

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -12,24 +12,57 @@ def slurm_get_max_acc(slurm_output, training_mode):
     accuracies = re.findall(re_acc, slurm_output)
     accuracies = [(int(i[0]), float(i[1])) for i in accuracies]
     
-    return max(accuracies, key=lambda x:x[1])
+    if accuracies:
+        return max(accuracies, key=lambda x:x[1])
+        
+        
+def slurm_count_epoch(slurm_output):
+    """Return count of epochs"""
+    epoch_times = re.findall('(\d:\d\d:\d\d) •', slurm_output)
+    
+    if epoch_times:
+        return len(epoch_times)
     
     
 def slurm_get_avg_epoch(slurm_output):
     """Return average epoch duration, in seconds"""
     epoch_times = re.findall('(\d:\d\d:\d\d) •', slurm_output)
-    epoch_times = [datetime.datetime.strptime(t, '%H:%M:%S') for t in epoch_times]
-    epoch_times = [datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second).seconds for t in epoch_times]
     
-    return math.ceil(sum(epoch_times) / len(epoch_times))
+    if epoch_times:
+        epoch_times = [datetime.datetime.strptime(t, '%H:%M:%S') for t in epoch_times]
+        epoch_times = [datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second).seconds for t in epoch_times]
+        return math.ceil(sum(epoch_times) / len(epoch_times))
     
 
 def stats_get_max_cpu(job_stats):
     """Return max CPU usage"""
     mem_usage = re.findall('\(([\d.]+)([\w]+)\/[\d.]+[\w]+ per core', job_stats)
-    if not mem_usage:
-        return None
-    gb_used = float(mem_usage[0][0])/1000 if mem_usage[0][1] == 'MB' else float(mem_usage[0][0])
     
-    return gb_used
+    if mem_usage:
+        gb_used = float(mem_usage[0][0])/1000 if mem_usage[0][1] == 'MB' else float(mem_usage[0][0])
+        return gb_used
 
+
+def calc_full_duration(slurm_output, job_stats):
+    """Given a preliminary slurm job output, return duration estimate:""" 
+    """Setup time, plus 50 times the average epoch plus 10% for wiggle room."""
+    """Assumes the train task will take 50 epochs."""
+    job_duration = re.findall('Run Time: (\d+:\d\d:\d\d)', job_stats)
+    epoch_avg = slurm_get_avg_epoch(slurm_output)
+    epoch_count = slurm_count_epoch(slurm_output)
+    
+    if epoch_avg and job_duration:
+        t = datetime.datetime.strptime(job_duration[0], '%H:%M:%S')
+        job_duration = datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second).seconds
+        setup_time = job_duration - ( epoch_avg * epoch_count )
+        
+        return datetime.timedelta(seconds=(setup_time + ( epoch_avg * 50 * 1.1 )))
+    
+
+def calc_cpu_mem(job_stats):
+    """Given a preliminary job_stats output, return recommended mem per cpu."""
+    gb_used = stats_get_max_cpu(job_stats)
+    
+    if gb_used:
+        return f"{math.ceil(gb_used + 0.3)}G"
+        

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -107,20 +107,20 @@ def estimate_cpu_mem(training_data_size, training_mode):
     
     if training_mode == "Segment":
         if training_data_size < 10000000:
-            mem_per_cpu = "1G"
+            mem_per_cpu = 1
         elif training_data_size < 20000000:
-            mem_per_cpu = "2G"
+            mem_per_cpu = 2
         elif training_data_size < 40000000:
-            mem_per_cpu = "3G"
+            mem_per_cpu = 3
         elif training_data_size < 120000000:
-            mem_per_cpu = "4G"
+            mem_per_cpu = 4
         elif training_data_size < 200000000:
-            mem_per_cpu = "5G"
+            mem_per_cpu = 5
         else:
-            mem_per_cpu = f"{6 + (training_data_size - 200000000) // 100000000}G"
+            mem_per_cpu = 6 + (training_data_size - 200000000) // 100000000
     else:
-        mem_per_cpu = "1G" if training_data_size < 50000000 else "2G"
+        mem_per_cpu = 1 if training_data_size < 50000000 else 2
         
-    return mem_per_cpu
+    return f"{mem_per_cpu}G"
 
         

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -44,9 +44,10 @@ def stats_get_max_cpu(job_stats):
 
 
 def calc_full_duration(slurm_output, job_stats):
-    """Given a preliminary slurm job output, return duration estimate:""" 
-    """Setup time, plus 50 times the average epoch plus 10% for wiggle room."""
-    """Assumes the train task will take 50 epochs."""
+    """Given a preliminary slurm job output, return duration estimate:
+    Setup time, plus 50 times the average epoch plus 10% for wiggle room.
+    Assumes the train task will take 50 epochs.
+    """
     job_duration = re.findall('Run Time: (\d+:\d\d:\d\d)', job_stats)
     epoch_avg = slurm_get_avg_epoch(slurm_output)
     epoch_count = slurm_count_epoch(slurm_output)
@@ -73,7 +74,7 @@ def estimate_duration(training_data_size, training_mode):
     if training_mode == "Segment":
         job_duration = datetime.timedelta(minutes=5) if training_data_size < 20000000 else datetime.timedelta(minutes=15)
     else:
-        job_duration = datetime.timedelta(minutes=5) if training_data_size < 5000000 else datetime.timedelta(minutes=15)
+        job_duration = datetime.timedelta(minutes=5) if training_data_size < 50000000 else datetime.timedelta(minutes=15)
         
     return job_duration
     
@@ -82,7 +83,7 @@ def estimate_cpu_mem(training_data_size, training_mode):
     """Use files in input data dir to come up with estimate of prelim mem per cpu."""
     
     if training_mode == "Segment":
-        if training_data_size < 5000000:
+        if training_data_size < 10000000:
             mem_per_cpu = "1G"
         elif training_data_size < 20000000:
             mem_per_cpu = "2G"

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -67,7 +67,7 @@ def calc_full_duration(slurm_output, job_stats):
             # if prelim train task already came close to 50 epochs or overshot it, run second train task
             # so that --lag 10 is immediately active (epoch_request -> --min-epochs 5) and so that the 
             # estimated job time request allows room for 15 more epochs.
-            epoch_time_est = 15 if epoch_request < 11 else epoch_time_est
+            epoch_time_est = 15 if epoch_request < 11 else epoch_request
             epoch_request = 5 if epoch_request < 11 else epoch_request
             
             return epoch_request, datetime.timedelta(minutes=math.ceil((setup_time + ( epoch_avg * epoch_time_est * 1.1 )) / 60))

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -95,11 +95,11 @@ def estimate_duration(training_data_size, training_mode):
     """Use files in input data dir to come up with estimate of prelim train duration."""
     
     if training_mode == "Segment":
-        job_duration = datetime.timedelta(minutes=5) if training_data_size < 20000000 else datetime.timedelta(minutes=15)
+        job_minutes = 5 if training_data_size < 20000000 else 15
     else:
-        job_duration = datetime.timedelta(minutes=5) if training_data_size < 50000000 else datetime.timedelta(minutes=15)
+        job_minutes = 5 if training_data_size < 50000000 else 15
         
-    return job_duration
+    return datetime.timedelta(minutes=job_minutes)
     
 
 def estimate_cpu_mem(training_data_size, training_mode):

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -66,3 +66,37 @@ def calc_cpu_mem(job_stats):
     if gb_used:
         return f"{math.ceil(gb_used + 0.3)}G"
         
+
+def estimate_duration(training_data_size, training_mode):
+    """Use files in input data dir to come up with estimate of prelim train duration."""
+    
+    if training_mode == "Segment":
+        job_duration = datetime.timedelta(minutes=5) if training_data_size < 20000000 else datetime.timedelta(minutes=15)
+    else:
+        job_duration = datetime.timedelta(minutes=5) if training_data_size < 5000000 else datetime.timedelta(minutes=15)
+        
+    return job_duration
+    
+
+def estimate_cpu_mem(training_data_size, training_mode):
+    """Use files in input data dir to come up with estimate of prelim mem per cpu."""
+    
+    if training_mode == "Segment":
+        if training_data_size < 5000000:
+            mem_per_cpu = "1G"
+        elif training_data_size < 20000000:
+            mem_per_cpu = "2G"
+        elif training_data_size < 40000000:
+            mem_per_cpu = "3G"
+        elif training_data_size < 120000000:
+            mem_per_cpu = "4G"
+        elif training_data_size < 200000000:
+            mem_per_cpu = "5G"
+        else:
+            mem_per_cpu = f"{6 + (training_data_size - 200000000) // 100000000}G"
+    else:
+        mem_per_cpu = "1G" if training_data_size < 50000000 else "2G"
+        
+    return mem_per_cpu
+
+        

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -1,0 +1,35 @@
+import re
+import math
+import datetime
+
+def slurm_get_max_acc(slurm_output, training_mode):
+    """Return a tuple of (epoch #, accuracy) for the epoch with highest accuracy"""
+    if training_mode == "Segment":
+        re_acc = 'stage ([\d]+).+\n[^i]*val_mean_iu:\s+\n\s+([\d.]+)'
+    else:
+        re_acc = 'stage ([\d]+).+\n.+(\d.\d\d\d)\s*\d/10'
+    
+    accuracies = re.findall(re_acc, slurm_output)
+    accuracies = [(int(i[0]), float(i[1])) for i in accuracies]
+    
+    return max(accuracies, key=lambda x:x[1])
+    
+    
+def slurm_get_avg_epoch(slurm_output):
+    """Return average epoch duration, in seconds"""
+    epoch_times = re.findall('(\d:\d\d:\d\d) •', slurm_output)
+    epoch_times = [datetime.datetime.strptime(t, '%H:%M:%S') for t in epoch_times]
+    epoch_times = [datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second).seconds for t in epoch_times]
+    
+    return math.ceil(sum(epoch_times) / len(epoch_times))
+    
+
+def stats_get_max_cpu(job_stats):
+    """Return max CPU usage"""
+    mem_usage = re.findall('\(([\d.]+)([\w]+)\/[\d.]+[\w]+ per core', job_stats)
+    if not mem_usage:
+        return None
+    gb_used = float(mem_usage[0][0])/1000 if mem_usage[0][1] == 'MB' else float(mem_usage[0][0])
+    
+    return gb_used
+

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -56,7 +56,7 @@ def calc_full_duration(slurm_output, job_stats):
         job_duration = datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second).seconds
         setup_time = job_duration - ( epoch_avg * epoch_count )
         
-        return datetime.timedelta(seconds=(setup_time + ( epoch_avg * 50 * 1.1 )))
+        return datetime.timedelta(minutes=math.ceil((setup_time + ( epoch_avg * 50 * 1.1 )) / 60))
     
 
 def calc_cpu_mem(job_stats):

--- a/src/htr2hpc/train/calculate.py
+++ b/src/htr2hpc/train/calculate.py
@@ -81,6 +81,10 @@ def calc_full_duration(slurm_output, job_stats):
             epoch_request = 50
             
             return epoch_request, datetime.timedelta(minutes=( 15 * 51 * 1.1 ))
+        else:
+            return None, None
+    else:
+        return None, None
     
 
 def calc_cpu_mem(job_stats):

--- a/src/htr2hpc/train/data.py
+++ b/src/htr2hpc/train/data.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import shutil
 from typing import Optional
 from collections import defaultdict
 from dataclasses import dataclass
@@ -251,6 +252,15 @@ def get_training_data(
 
     # return the total counts for various pieces of training data
     return counts
+    
+
+def get_prelim_model(input_model: pathlib.Path):
+    """Copies the input model to a file with suffix `_prelim.mlmodel`, 
+    then returns the path to that newly created file.
+    """
+    prelim_model = input_model.parent / ('_'.join(input_model.name.split('_')[:-1]) + '_prelim.mlmodel')
+    shutil.copy(input_model, prelim_model)
+    return prelim_model
 
 
 def get_best_model(

--- a/src/htr2hpc/train/data.py
+++ b/src/htr2hpc/train/data.py
@@ -166,8 +166,8 @@ def split_segmentation(training_data_dir):
     files_validate = [f"parts/{f.name}" for f in files_xml[::10]]
     files_train = [f"parts/{f.name}" for f in files_xml if f"parts/{f.name}" not in files_validate]
     
-    print(files_validate)
-    print(files_train)
+    logger.info(f"Files in train set:\n {files_train}")
+    logger.info(f"Files in validation set:\n {files_validate}")
     
     train_path = training_data_dir / "train.txt"
     validate_path = training_data_dir / "validate.txt"

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -259,19 +259,14 @@ class TrainingManager:
             print("Best model already found.")
             return
         
-        # check exit status first
-        job_status = slurm_job_status(job_id)
-        if "OUT_OF_MEMORY" in job_status:
-            # might want to split up handling here more. OUT_OF_MEMORY might indicate
-            # odd cases like a seg train task with no regions, or it might indicate
-            # that the memory should be raised and the train task attempted again.
-            self.upload_best()
-            
-        else:
+        # otherwise prepare to run a second task, 
+        # refining on the preliminary model and using the new duration / cpu requests
+        abs_prelim_model_file, full_duration, mem_per_cpu = self.calc_updated_params(abs_model_file)
         
-            abs_prelim_model_file, full_duration, mem_per_cpu = self.calc_updated_params(abs_model_file)
-            
-            # run a second slurm task, refining on the preliminary model and using the new duration / cpu requests
+        # if values for parameters were found, then the previous train task ran without errors
+        # and the second one can be submitted
+        if full_duration and mem_per_cpu:
+            print(f"Requesting {mem_per_cpu} at {full_duration}.")
             os.chdir(self.work_dir)
                 
             job_id = segtrain(
@@ -331,19 +326,14 @@ class TrainingManager:
             print("Best model already found.")
             return
         
-        # check exit status first
-        job_status = slurm_job_status(job_id)
-        if "OUT_OF_MEMORY" in job_status:
-            # might want to split up handling here more. OUT_OF_MEMORY might indicate
-            # odd cases like a seg train task with no regions, or it might indicate
-            # that the memory should be raised and the train task attempted again.
-            self.upload_best()
-            
-        else:
+        # otherwise prepare to run a second task, 
+        # refining on the preliminary model and using the new duration / cpu requests
+        abs_prelim_model_file, full_duration, mem_per_cpu = self.calc_updated_params(abs_model_file)
         
-            abs_prelim_model_file, full_duration, mem_per_cpu = self.calc_updated_params(abs_model_file)
-            
-            # run a second slurm task, refining on the preliminary model and using the new duration / cpu requests
+        # if values for parameters were found, then the previous train task ran without errors
+        # and the second one can be submitted
+        if full_duration and mem_per_cpu:
+            print(f"Requesting {mem_per_cpu} at {full_duration}.")
             os.chdir(self.work_dir)
             
             job_id = recognition_train(
@@ -356,9 +346,9 @@ class TrainingManager:
             )
             os.chdir(self.orig_working_dir)
             self.monitor_slurm_job(job_id)
-            
-            
-            self.upload_best()
+        
+        
+        self.upload_best()
             
     
     def calc_updated_params(self, abs_model_file):

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -244,7 +244,6 @@ class TrainingManager:
             abs_training_data_dir,
             abs_model_file,
             abs_output_modelfile,
-            self.training_data_counts,
             self.num_workers,
             mem_per_cpu = prelim_cpu_mem,
             training_time = prelim_train_time,

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -242,8 +242,8 @@ class TrainingManager:
 
         job_id = segtrain(
             abs_training_data_dir,
-            abs_model_file,
             abs_output_modelfile,
+            abs_model_file,
             self.num_workers,
             mem_per_cpu = prelim_cpu_mem,
             training_time = prelim_train_time,

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -361,11 +361,20 @@ class TrainingManager:
         
         # if there was no preliminary best model, use old `abs_model_file` in case train task was
         # refining upon an input model.
-        if not abs_prelim_model_file:
+        else:
             abs_prelim_model_file = abs_model_file
 
         full_duration = calc_full_duration(self.slurm_output, self.job_stats)
         mem_per_cpu = calc_cpu_mem(self.job_stats)
+        
+        try:
+            best_epoch, best_acc = best_epoch_acc
+        except:
+            best_epoch, best_acc = None, None
+        if [mem_per_cpu, full_duration, best_epoch_acc] == [None, None, None]:
+            msg = "Encountered errors. Ending script..."
+        else:
+            msg = "Submitting next slurm job..."
         
         task_report = self.api.task_details(self.task_report_id)
         self.api.task_update(
@@ -377,8 +386,8 @@ class TrainingManager:
             Preliminary train task to calibrate requirements completed.
             - The recommended mem per cpu is {mem_per_cpu}
             - The recommended duration time is {full_duration}
-            - The epoch with the highest accuracy was {best_epoch_acc[0]} with {best_epoch_acc[1]}.
-            Submitting next slurm job...""",
+            - The epoch with the highest accuracy was {best_epoch} with {best_acc}.
+            {msg}""",
         )
         return abs_prelim_model_file, full_duration, mem_per_cpu
     

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -261,7 +261,7 @@ class TrainingManager:
         
         # otherwise prepare to run a second task, 
         # refining on the preliminary model and using the new duration / cpu requests
-        abs_prelim_model_file, full_duration, mem_per_cpu = self.calc_updated_params(abs_model_file)
+        abs_prelim_model_file, full_duration, mem_per_cpu, epoch_request = self.calc_updated_params(abs_model_file)
         
         # if values for parameters were found, then the previous train task ran without errors
         # and the second one can be submitted
@@ -276,6 +276,7 @@ class TrainingManager:
                 self.num_workers,
                 mem_per_cpu = mem_per_cpu,
                 training_time = full_duration,
+                epochs = epoch_request,
             )
             os.chdir(self.orig_working_dir)
             self.monitor_slurm_job(job_id)
@@ -328,7 +329,7 @@ class TrainingManager:
         
         # otherwise prepare to run a second task, 
         # refining on the preliminary model and using the new duration / cpu requests
-        abs_prelim_model_file, full_duration, mem_per_cpu = self.calc_updated_params(abs_model_file)
+        abs_prelim_model_file, full_duration, mem_per_cpu, epoch_request = self.calc_updated_params(abs_model_file)
         
         # if values for parameters were found, then the previous train task ran without errors
         # and the second one can be submitted
@@ -343,6 +344,7 @@ class TrainingManager:
                 self.num_workers,
                 mem_per_cpu = mem_per_cpu,
                 training_time = full_duration,
+                epochs = epoch_request,
             )
             os.chdir(self.orig_working_dir)
             self.monitor_slurm_job(job_id)
@@ -364,7 +366,7 @@ class TrainingManager:
         else:
             abs_prelim_model_file = abs_model_file
 
-        full_duration = calc_full_duration(self.slurm_output, self.job_stats)
+        epoch_request, full_duration = calc_full_duration(self.slurm_output, self.job_stats)
         mem_per_cpu = calc_cpu_mem(self.job_stats)
         
         try:
@@ -385,11 +387,11 @@ class TrainingManager:
             
             Preliminary train task to calibrate requirements completed.
             - The recommended mem per cpu is {mem_per_cpu}
-            - The recommended duration time is {full_duration}
-            - The epoch with the highest accuracy was {best_epoch} with {best_acc}.
+            - The recommended duration time is {full_duration} for {epoch_request} epochs.
+            - The prelim epoch with the highest accuracy was {best_epoch} with {best_acc}.
             {msg}""",
         )
-        return abs_prelim_model_file, full_duration, mem_per_cpu
+        return abs_prelim_model_file, full_duration, mem_per_cpu, epoch_request
     
 
     def upload_best(self):

--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -81,7 +81,7 @@ class TrainingManager:
     model_file: pathlib.Path = None
     training_data_counts: Optional[dict] = None
     slurm_output: str = ""
-    job_stats: str = None
+    job_stats: str = ""
 
     def __post_init__(self):
         if self.update and not self.model_id:
@@ -244,11 +244,7 @@ class TrainingManager:
         
         # check exit status first
         job_status = slurm_job_status(job_id)
-        if "CANCELLED" in job_status and "TIMEOUT" not in job_status:
-            # cancelled by user, do run another train task, do not upload a model
-            return
-            
-        elif "OUT_OF_MEMORY" in job_status:
+        if "OUT_OF_MEMORY" in job_status:
             # might want to split up handling here more. OUT_OF_MEMORY might indicate
             # odd cases like a seg train task with no regions, or it might indicate
             # that the memory should be raised and the train task attempted again.
@@ -294,11 +290,7 @@ class TrainingManager:
         
         # check exit status first
         job_status = slurm_job_status(job_id)
-        if "CANCELLED" in job_status and "TIMEOUT" not in job_status:
-            # cancelled by user, do run another train task, do not upload a model
-            return
-            
-        elif "OUT_OF_MEMORY" in job_status:
+        if "OUT_OF_MEMORY" in job_status:
             # might want to split up handling here more. OUT_OF_MEMORY might indicate
             # odd cases like a seg train task with no regions, or it might indicate
             # that the memory should be raised and the train task attempted again.

--- a/src/htr2hpc/train/slurm.py
+++ b/src/htr2hpc/train/slurm.py
@@ -16,23 +16,18 @@ def segtrain(
     output_model: pathlib.Path,
     input_data_counts: TrainingDataCounts,
     num_workers: int = 8,
+    mem_per_cpu: str = "4G",
+    training_time: datetime.timedelta = datetime.timedelta(minutes=15),
     # optional param to specify name based on document? include date?
 ) -> int:
     """Run ketos segmentation training as a slurm job.
     Returns the slurm job id for the queued job."""
 
-    logger.info(
-        f"training data: {input_data_counts.parts:,} parts, {input_data_counts.regions:,} regions, {input_data_counts.lines:,} lines"
-    )
-    # set training time here based on input data size; can be any number of minutes
-    training_time = datetime.timedelta(minutes=15)
-    logger.info(f"requesting {training_time}")
-
     segtrain_slurm = Slurm(
         nodes=1,
         ntasks=1,
         cpus_per_task=num_workers,
-        mem_per_cpu="4G",
+        mem_per_cpu=mem_per_cpu,
         gres=["gpu:1"],
         job_name=f"segtrain:{output_model.name}",
         output=f"segtrain_{Slurm.JOB_ARRAY_MASTER_ID}.out",
@@ -67,24 +62,18 @@ def recognition_train(
     output_model: pathlib.Path,
     input_model: pathlib.Path = None,
     num_workers: int = 8,
+    mem_per_cpu: str = "2G",
+    training_time: datetime.timedelta = datetime.timedelta(minutes=15),
     # optional param to specify name based on document? include date?
 ) -> int:
     """Run ketos recognition training as a slurm job.
     Returns the slurm job id for the queued job."""
 
-    # we expect training data to be a binary arrow file in the data dir
-    training_data_file = input_data_dir / "train.arrow"
-    training_data_size = training_data_file.stat().st_size
-    logger.info(f"training data file {training_data_file} size is {training_data_size}")
-    # set training time here based on file size; can be any number of minutes
-    training_time = datetime.timedelta(minutes=15)
-    logger.info(f"requesting {training_time}")
-
     recogtrain_slurm = Slurm(
         nodes=1,
         ntasks=1,
         cpus_per_task=num_workers,
-        mem_per_cpu="2G",
+        mem_per_cpu=mem_per_cpu,
         gres=["gpu:1"],
         job_name=f"train:{output_model.name}",
         output=f"train_{Slurm.JOB_ARRAY_MASTER_ID}.out",

--- a/src/htr2hpc/train/slurm.py
+++ b/src/htr2hpc/train/slurm.py
@@ -136,7 +136,5 @@ def slurm_job_stats(job_id: int) -> str:
         capture_output=True,
         text=True,
     )
-    # raise subprocess.CalledProcessError if return code indicates an error
-    result.check_returncode()
     # return task status without any whitespace
     return result.stdout.strip()

--- a/src/htr2hpc/train/slurm.py
+++ b/src/htr2hpc/train/slurm.py
@@ -14,7 +14,6 @@ def segtrain(
     input_data_dir: pathlib.Path,
     input_model: pathlib.Path,
     output_model: pathlib.Path,
-    input_data_counts: TrainingDataCounts,
     num_workers: int = 8,
     mem_per_cpu: str = "4G",
     training_time: datetime.timedelta = datetime.timedelta(minutes=15),

--- a/src/htr2hpc/train/slurm.py
+++ b/src/htr2hpc/train/slurm.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 def segtrain(
     input_data_dir: pathlib.Path,
-    input_model: pathlib.Path,
     output_model: pathlib.Path,
+    input_model: pathlib.Path,
     num_workers: int = 8,
     mem_per_cpu: str = "4G",
     training_time: datetime.timedelta = datetime.timedelta(minutes=15),

--- a/src/htr2hpc/train/slurm.py
+++ b/src/htr2hpc/train/slurm.py
@@ -48,7 +48,7 @@ def segtrain(
         # run with default number of epochs (50)
         f"ketos segtrain --resize both -i {input_model} -q early"
         + f" -o {output_model} --workers {num_workers} -d cuda:0 "
-        + f"-f xml {input_data_dir}/*.xml "
+        + f"-f xml -t {input_data_dir}/train.txt -e {input_data_dir}/validate.txt"
         # + "--precision 16"  # automatic mixed precision for nvidia gpu
     )
 


### PR DESCRIPTION
Preliminary work on #49 . 

I still need to add in preliminary code that defines the train / validation split for both train tasks (rather than letting kraken randomly select the split each time, which leads to contamination between the two jobs). Probably more error handling to be added as well.

But for now:
- runs a short (max 15 mins) preliminary train task using roughly estimated resource requests
- parses the `.out` file and `job_stats` to check epoch count, avg duration, max cpu usage
- if a `_best.mlmodel` model already found, returns it and ends here
- otherwise, calculates more accurate resource requests for the next train task's full run time
- finds the highest accuracy model from the prelim train task, if extant, and inputs it as the model for the next train task to refine on
- finds the best model from the second train task and returns it to escr

Task messages are updated with the `.out` file and `job_stats` as each task completes.