### PR TITLE
Add deploy notes for creating a release and deploying with ansible

### DIFF
--- a/DEPLOY_NOTES.md
+++ b/DEPLOY_NOTES.md
@@ -1,0 +1,57 @@
+# Deploy Notes
+
+
+We use the [git-flow branching pattern](https://www.gitkraken.com/learn/git/git-flow) for this codebase. This means that `main` is always the most recent release and `develop` has new features for the next release.
+
+We recommend installing git-flow. On OSX, you can install with brew:
+```sh
+brew install git-flow
+```
+
+In your local checkout of htr2hpc code, run `git flow init` to initialize the repository with git-flow and accept all the defaults.
+
+## Creating a new release
+
+Use git flow to create a release candidate. Specify the version number of the new release you are planning to create; e.g., for version 0.5:
+
+```sh
+git flow release start 0.5
+```
+
+1. Update the version number in `src/htr2hpc/__init__.py`
+2. Update the change log (`CHANGELOG.md`) to document changes in the new version.
+
+Do any checking you want to do to verify the changes (e.g., git diff against `main` or previous release, or creating a pull request on GitHub to review the changes).
+
+When you are done making changes, you can use git flow to finish the release:
+
+```sh
+git flow release finish 0.5
+```
+
+This will merge your changes into `main`, `develop`, and create a new tag for your version.
+
+When you create the tag, you can add a brief message describing the release, e.g.:
+
+```
+v0.5 - initial release for beta testing
+```
+
+Push all the changes to GitHub:
+
+```sh
+git checkout main
+git push
+git checkout develop
+git push
+git push --tags
+```
+
+## Deploying a new release
+
+Once the new release has been merged to `main` and pushed to GitHub, you can use the cdh-ansible playbook to update the version of htr2hpc installed on the escriptorium test server using the *htr2hpc-reinstall* tag:
+
+```sh
+ansible-playbook playbooks/escriptorium.yml -t reinstall-htr2hpc
+```
+

--- a/DEPLOY_NOTES.md
+++ b/DEPLOY_NOTES.md
@@ -8,18 +8,18 @@ We recommend installing git-flow. On OSX, you can install with brew:
 brew install git-flow
 ```
 
-In your local checkout of htr2hpc code, run `git flow init` to initialize the repository with git-flow and accept all the defaults.
+In your local checkout of htr2hpc code, run `git flow init` to initialize the repository with git-flow and accept all the defaults. (This is a one-time step.)
 
 ## Creating a new release
 
-Use git flow to create a release candidate. Specify the version number of the new release you are planning to create; e.g., for version 0.5:
+Use git flow to create a branch to prep a new release. Specify the version number of the new release you are planning to create; e.g., for version 0.5:
 
 ```sh
 git flow release start 0.5
 ```
 
 1. Update the version number in `src/htr2hpc/__init__.py`
-2. Update the change log (`CHANGELOG.md`) to document changes in the new version.
+2. Update `CHANGELOG.md` to document changes in the new version.
 
 Do any checking you want to do to verify the changes (e.g., git diff against `main` or previous release, or creating a pull request on GitHub to review the changes).
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ pip install git+https://github.com/Princeton-CDH/htr2hpc.git@main#egg=htr2hpc
 
 Import htr2hpc settings into the deployed escriptorium local settings. It must be imported *after* escriptorium settings so that overrides take precedence. 
 
-
-
 ```python
 from escriptorium.settings import *
 from htr2hpc.settings import *
@@ -36,6 +34,8 @@ This adjusts the settings as follows:
 - Adds to `INSTALLED_APPS` and `AUTHENTICATION_BACKENDS` and provides a basic `PUCAS_LDAP` configuration to enable Princeton CAS authentication; configures `CAS_REDIRECT_URL` to use the escriptorium `LOGIN_REDIRECT_URL` configuration (currently the projects list page) and sets `CAS_IGNORE_REFERER = True` to avoid behavior where successful CAS login takes you back to the login page
 - Sets `ROOT_URLCONF` to use `htr2hpc.urls`, which adds `pucas` url paths to the urls defined in `escriptorium.urls`
 - Adds `htr2hpc/templates` directory first in the list of template directories, so that any templates in this application will take precedence over eScriptorium templates; currently used for customizing the login page to add Princeton CAS login
+
+See [DEPLOY NOTES](DEPLOY_NOTES.md) for instructions on creating a new release and deploying it to the server with cdh-ansible.
 
 ### Configure CAS authentication
 


### PR DESCRIPTION
- Adds a deploy notes document with instructions for creating a new release and deploying it
- Adds a link from the readme to the deploy notes

You can preview the rendered markdown for the deploy notes file here:
https://github.com/Princeton-CDH/htr2hpc/blob/feature/document-release-deploy/DEPLOY_NOTES.md

