### PR TITLE
Add architecture and sequence diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ The project goal is integrating the [eScriptorium handwritten text recognition (
 
 ## Table of Contents
 
-- [Installation](#installation)
+- [Installation](#installation-and-usage)
+- [Architecture](#architecture)
 - [License](#license)
 
-## Installation and usage
+## Installation and usage 
 
 This package can be installed directly from GitHub using `pip`:
 
@@ -61,6 +62,39 @@ PUCAS_LDAP.update(
 )
 ```
 
+## Architecture 
+
+This architecture chart shows how the eScriptorium test instance was deployed on Princeton hardware during the testing phase. 
+
+
+```mermaid
+flowchart TB
+ subgraph hpc["HPC"]
+        remote[["remote task"]]
+  end
+ subgraph htrvm["eScriptorium VM"]
+        Django["Django"]
+        nginx["NGINX"]
+        redis[("redis")]
+        supervisord["supervisord"]
+        celery["celery"]
+        local[["local task"]]
+  end
+ subgraph pul["PUL infrastructure"]
+        db[("PostgreSQL")]
+        nfs[/"NFS"\]
+        htrvm
+  end
+    nginx -- serves --> Django
+    Django --> db
+    Django -- queues tasks --> redis
+    supervisord -- manages --> celery
+    celery -- monitors --> redis
+    celery -- runs --> local & remote
+    htrvm --> nfs
+```
+
+For simplicity, we omit the second VM and load balancer; the two VMs are provisioned and deployed in the same way, and use shared PUL and HPC resources.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For simplicity, we omit the second VM and load balancer; the two VMs are provisi
 This sequence diagram shows the flow of operations between eScriptorium instance, htr2hpc installation on the HPC system, and Slurm. 
 
 The task is triggered via ssh, then training data and optionally a model are retrieved via REST API. The htr2hpc training task uses a 
-two-job workflow with a preliminary calibration job before requesting second training job with resources and time requested based on the training job.
+two-job workflow with a preliminary calibration job before requesting second training job with resources and time requested based on the results of the calibration job.
 
 ```mermaid
 sequenceDiagram

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The project goal is integrating the [eScriptorium handwritten text recognition (
 ## Table of Contents
 
 - [Installation](#installation-and-usage)
-- [Architecture](#architecture)
+- [Architecture and Flow](#architecture-and-flow)
 - [License](#license)
 
 ## Installation and usage 
@@ -62,9 +62,12 @@ PUCAS_LDAP.update(
 )
 ```
 
-## Architecture 
+## Architecture and Flow
 
-This architecture chart shows how the eScriptorium test instance was deployed on Princeton hardware during the testing phase. 
+
+### Deployment
+
+This architecture diagram shows how the eScriptorium instance was deployed on Princeton hardware during the testing phase. 
 
 
 ```mermaid
@@ -95,6 +98,37 @@ flowchart TB
 ```
 
 For simplicity, we omit the second VM and load balancer; the two VMs are provisioned and deployed in the same way, and use shared PUL and HPC resources.
+
+### Remote training flow
+
+This sequence diagram shows the flow of operations between eScriptorium instance, htr2hpc installation on the HPC system, and Slurm. 
+
+The task is triggered via ssh, then training data and optionally a model are retrieved via REST API. The htr2hpc training task uses a 
+two-job workflow with a preliminary calibration job before requesting second training job with resources and time requested based on the training job.
+
+```mermaid
+sequenceDiagram
+  participant htrvm as htrvm
+  participant htr2hpc as htr2hpc
+  participant slurm as slurm
+  autonumber
+  htrvm ->>+ htr2hpc: Start training task
+  activate htr2hpc
+  htr2hpc -) htrvm: request data
+  htr2hpc --) htrvm: request model
+  htr2hpc ->> slurm: start calibration job
+  activate slurm
+  htr2hpc --x slurm: monitor job
+  slurm ->> htr2hpc: calibration output
+  deactivate slurm
+  htr2hpc ->> slurm: start training job
+  activate slurm
+  htr2hpc --x slurm: monitor job
+  deactivate slurm
+  htr2hpc -) htrvm: upload model
+  deactivate htr2hpc
+```
+
 
 ## License
 


### PR DESCRIPTION
**Associated Issue(s):** #55 

### Changes in this PR

- Updated main readme with mermaid diagrams for deploy architecture and remote task sequence
- Included brief text describing the charts (adapted in part from the paper)

### Notes

- I added these directly to the readme because it was short enough, it didn't seem like this content warranted a new file (and putting it elsewhere makes it less likely that people will find it. I don't feel strongly about this.
- We should add a link to the paper once it is deposited!


You can see the preview with diagrams rendered here: https://github.com/Princeton-CDH/htr2hpc/tree/rlskoeser-patch-1?tab=readme-ov-file#architecture-and-flow
