### PR TITLE
Add Django admin interface for CAS user management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pucas>=0.9",    # TODO: move to an optional group for webapp integration only?
+  "pucas @ git+https://github.com/Princeton-CDH/django-pucas@feature/add-init-cas-user",    # TODO: move to an optional group for webapp integration only?
   "psutil",
   "requests",
   "kraken",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pucas @ git+https://github.com/Princeton-CDH/django-pucas@feature/add-init-cas-user",    # TODO: move to an optional group for webapp integration only?
+  "pucas @ git+https://github.com/Princeton-CDH/django-pucas@develop",    # TODO: move to an optional group for webapp integration only?
   "psutil",
   "requests",
   "kraken",

--- a/src/htr2hpc/admin.py
+++ b/src/htr2hpc/admin.py
@@ -1,0 +1,15 @@
+from django.contrib import admin
+from django.contrib.auth import get_user_model
+
+from pucas.admin import CasUserAdmin
+from users.admin import MyUserAdmin
+
+
+class Htr2HpcUserAdmin(CasUserAdmin, MyUserAdmin):
+    """Extends eScriptorium's UserAdmin with pucas CAS user management."""
+    pass
+
+
+# replace eScriptorium's User registration with our extended admin
+admin.site.unregister(get_user_model())
+admin.site.register(get_user_model(), Htr2HpcUserAdmin)

--- a/src/htr2hpc/apps.py
+++ b/src/htr2hpc/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class Htr2HpcConfig(AppConfig):
+    name = "htr2hpc"
+
+    def ready(self):
+        import htr2hpc.admin  # noqa: F401 — registers admin overrides

--- a/src/htr2hpc/settings.py
+++ b/src/htr2hpc/settings.py
@@ -6,7 +6,7 @@ from escriptorium.settings import INSTALLED_APPS, LOGIN_REDIRECT_URL, TEMPLATES
 HTR2HPC_INSTALL_DIR = Path(__file__).parent
 
 
-INSTALLED_APPS += ["django_cas_ng", "pucas", "htr2hpc"]
+INSTALLED_APPS += ["django_cas_ng", "pucas", "htr2hpc.apps.Htr2HpcConfig"]
 AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
     "django_cas_ng.backends.CASBackend",

--- a/src/htr2hpc/users.py
+++ b/src/htr2hpc/users.py
@@ -1,15 +1,21 @@
+import datetime
 from typing import Any
 
 from django.contrib.auth.models import AbstractUser
+from django.utils import timezone
 
 
 def init_user(user: AbstractUser, user_info: Any) -> None:
     """pucas EXTRA_USER_INIT hook: make new CAS accounts inactive by default.
 
     Staff and superuser accounts are left active so admin access is not
-    interrupted when accounts are re-initialized.
+    interrupted when accounts are re-initialized. Existing regular user
+    accounts are also left unchanged to preserve any intentional changes
+    (e.g. is_active set by an admin).
     """
-    # admins must explicitly activate accounts before users can log in;
-    # skip for staff/superusers so their access is not disrupted
-    if not (user.is_staff or user.is_superuser):
+    if user.is_staff or user.is_superuser:
+        return
+    # treat accounts created within the last 5 seconds as new
+    just_created = (timezone.now() - user.date_joined) < datetime.timedelta(seconds=5)
+    if just_created:
         user.is_active = False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -39,8 +39,12 @@ DATABASES = {
 }
 
 INSTALLED_APPS = [
+    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.messages",
+    "django.contrib.sessions",
+    "captcha",
     "rest_framework",
     "rest_framework.authtoken",
     "users",
@@ -51,6 +55,21 @@ AUTH_USER_MODEL = "users.User"
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 ROOT_URLCONF = "htr2hpc.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
 
 
 class DisableMigrations:

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,36 +1,46 @@
 """Tests for htr2hpc.users."""
-from unittest.mock import Mock
+import datetime
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import User
+from django.utils import timezone
 
 from htr2hpc.users import init_user
 
 
-def test_init_user_sets_inactive():
-    user = Mock(spec=User, is_staff=False, is_superuser=False, is_active=True)
+def make_user(is_staff=False, is_superuser=False, is_active=True, seconds_old=1):
+    """Create a mock user with date_joined set to seconds_old seconds ago."""
+    user = Mock(spec=User, is_staff=is_staff, is_superuser=is_superuser, is_active=is_active)
+    user.date_joined = timezone.now() - datetime.timedelta(seconds=seconds_old)
+    return user
+
+
+def test_new_user_set_inactive():
+    user = make_user(seconds_old=1)
     init_user(user, {})
     assert user.is_active is False
 
 
+def test_existing_user_not_changed():
+    user = make_user(seconds_old=60)
+    original_active = user.is_active
+    init_user(user, {})
+    assert user.is_active == original_active
+
+
 def test_init_user_ignores_user_info():
-    user = Mock(spec=User, is_staff=False, is_superuser=False, is_active=True)
+    user = make_user(seconds_old=1)
     init_user(user, {"uid": "netid123", "mail": "netid@example.com"})
     assert user.is_active is False
 
 
-def test_init_user_already_inactive():
-    user = Mock(spec=User, is_staff=False, is_superuser=False, is_active=False)
-    init_user(user, {})
-    assert user.is_active is False
-
-
 def test_init_user_staff_stays_active():
-    user = Mock(spec=User, is_staff=True, is_superuser=False, is_active=True)
+    user = make_user(is_staff=True, seconds_old=1)
     init_user(user, {})
     assert user.is_active is True
 
 
 def test_init_user_superuser_stays_active():
-    user = Mock(spec=User, is_staff=False, is_superuser=True, is_active=True)
+    user = make_user(is_superuser=True, seconds_old=1)
     init_user(user, {})
     assert user.is_active is True


### PR DESCRIPTION
**Associated Issue(s):** resolves #64

### Changes in this PR
- Add `apps.py` with `Htr2HpcConfig.ready()` to register admin overrides on startup
- Add `admin.py` with `Htr2HpcUserAdmin` — subclasses `CasUserAdmin` from pucas and eScriptorium's `MyUserAdmin` to opt in to the CAS user initialization interface
- Update `users.py` to keep only the `init_user()` hook; use `date_joined` to set only newly created accounts inactive (existing accounts are left unchanged)
- Update `settings.py` to use `htr2hpc.apps.Htr2HpcConfig` app entry and point `EXTRA_USER_INIT` to `init_user`
- Update `pyproject.toml` to depend on pucas `feature/add-init-cas-user` branch until both are released

### Notes
- The form, view, and templates for CAS user initialization live in pucas; see princeton-cdh/django-pucas#32
- htr2hpc integration is minimal: just registering `Htr2HpcUserAdmin` and the `init_user` hook

### Reviewer Checklist
- [ ] Confirm "Add CAS Users" button appears on the user changelist in the admin
- [ ] Submit one or more valid netids and confirm accounts are created and set inactive
- [ ] Submit an invalid netid and confirm an error is shown
- [ ] Submit an existing netid and confirm "Already exists" is reported
- [ ] Confirm re-initializing an existing user does not change their `is_active` status