### PR TITLE
Display htr2hpc version in site footer

### DIFF
--- a/src/htr2hpc/context_processors.py
+++ b/src/htr2hpc/context_processors.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 from os import cpu_count, getloadavg
 from socket import gethostname
 
@@ -39,3 +40,8 @@ def vm_status(request):
         },
         "system_memory": system_memory,
     }
+
+
+def htr2hpc_version(request):
+    """Custom context processor to expose the htr2hpc package version."""
+    return {"HTR2HPC_VERSION": importlib.metadata.version("htr2hpc")}

--- a/src/htr2hpc/context_processors.py
+++ b/src/htr2hpc/context_processors.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 from os import cpu_count, getloadavg
 from socket import gethostname
 
@@ -44,4 +43,6 @@ def vm_status(request):
 
 def htr2hpc_version(request):
     """Custom context processor to expose the htr2hpc package version."""
-    return {"HTR2HPC_VERSION": importlib.metadata.version("htr2hpc")}
+    from htr2hpc import __version__
+
+    return {"HTR2HPC_VERSION": __version__}

--- a/src/htr2hpc/settings.py
+++ b/src/htr2hpc/settings.py
@@ -41,9 +41,12 @@ TEMPLATES[0]["DIRS"].insert(0, HTR2HPC_INSTALL_DIR / "templates")
 # But to override escriptorium templates, we need to treat it as a
 # template directory and put it first in the list.
 
-# add custom context processor to display VM status
+# add custom context processors to display VM status and htr2hpc version
 TEMPLATES[0]["OPTIONS"]["context_processors"].append(
     "htr2hpc.context_processors.vm_status"
+)
+TEMPLATES[0]["OPTIONS"]["context_processors"].append(
+    "htr2hpc.context_processors.htr2hpc_version"
 )
 
 

--- a/src/htr2hpc/templates/additional_footer.html
+++ b/src/htr2hpc/templates/additional_footer.html
@@ -1,4 +1,8 @@
 
+<div class="col-12">
+    <p class="text-muted mt-2"><a href="https://github.com/Princeton-CDH/htr2hpc" target="_blank">htr2hpc</a> version {{ HTR2HPC_VERSION }}</p>
+</div>
+
 <div class="row">
     <div class="col-12">
         <hr/>

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -1,11 +1,11 @@
 import importlib.metadata
-from unittest.mock import MagicMock
 
+from htr2hpc import __version__
 from htr2hpc.context_processors import htr2hpc_version
 
 
 def test_htr2hpc_version():
-    request = MagicMock()
-    context = htr2hpc_version(request)
+    context = htr2hpc_version(None)
     assert "HTR2HPC_VERSION" in context
+    assert context["HTR2HPC_VERSION"] == __version__
     assert context["HTR2HPC_VERSION"] == importlib.metadata.version("htr2hpc")

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -1,0 +1,11 @@
+import importlib.metadata
+from unittest.mock import MagicMock
+
+from htr2hpc.context_processors import htr2hpc_version
+
+
+def test_htr2hpc_version():
+    request = MagicMock()
+    context = htr2hpc_version(request)
+    assert "HTR2HPC_VERSION" in context
+    assert context["HTR2HPC_VERSION"] == importlib.metadata.version("htr2hpc")


### PR DESCRIPTION
**Associated Issue(s):** resolves #78

### Changes in this PR
- Add `htr2hpc_version` context processor that reads the package version via `importlib.metadata`
- Register the new context processor in `settings.py`
- Update `additional_footer.html` to display the htr2hpc version with a link to the GitHub repo
- Add test for the new context processor

### Notes
- I've verified the change locally, which correctly renders the footer with the version 0.5.0. (The version shown is from the `@main` install in the Docker image; on staging/prod it will reflect the actual installed version.)

### Reviewer Checklist
- [ ] Acceptance testing tracked in #100