### PR TITLE
Feature/kraken6

### DIFF
--- a/src/htr2hpc/train/run.py
+++ b/src/htr2hpc/train/run.py
@@ -426,7 +426,7 @@ class TrainingManager:
         )
         if best_model:
             # TODO: revise message to include info about created/updated model id ##
-            print(f"Uploaded {best_model} to eScriptorum")
+            print(f"Uploaded {best_model} to eScriptorium")
         else:
             # possibly best model found but upload failed?
             print("No best model found")

--- a/src/htr2hpc/train/slurm.py
+++ b/src/htr2hpc/train/slurm.py
@@ -52,9 +52,9 @@ def segtrain(
     logger.info(f"sbatch file\n: {segtrain_slurm}")
     # sbatch returns the job id for the created job
     segtrain_cmd = (
-        f"ketos segtrain --min-epochs {epochs} --resize both -i {input_model} -q early"
-        + f" -o {output_model} --workers {num_workers} -d cuda:0 "
-        + f"-f xml -t {input_data_dir}/train.txt -e {input_data_dir}/validate.txt"
+        f"ketos --workers {num_workers} -d cuda:0 segtrain "
+        + f"--min-epochs {epochs} --resize both -i {input_model} -q early -o {output_model} "
+        + f"-f xml -t {input_data_dir}/train.txt -e {input_data_dir}/validate.txt "
         # + "--precision 16"  # automatic mixed precision for nvidia gpu
     )
 
@@ -101,8 +101,8 @@ def recognition_train(
     # input model is optional; resize is only used with exesting model
     input_model_opt = f"--resize new -i {input_model}" if input_model else ""
     recogtrain_cmd = (
-        f"ketos train --min-epochs {epochs} {input_model_opt}"
-        + f" -o {output_model} --workers {num_workers} -d cuda:0 "
+        f"ketos --workers {num_workers} -d cuda:0 train "
+        + f"--min-epochs {epochs} {input_model_opt} -o {output_model} "
         + f"-f binary {input_data_dir}/train.arrow "
         + "-w 0 -s '[1,120,0,1 Cr3,13,32 Do0.1,2 Mp2,2 Cr3,13,32 Do0.1,2 Mp2,2 Cr3,9,64 Do0.1,2 Mp2,2 Cr3,9,64 Do0.1,2 S1(1x0)1,3 Lbx200 Do0.1,2 Lbx200 Do.1,2 Lbx200 Do]' -r 0.0001"
     )

--- a/src/htr2hpc/train/user_setup.sh
+++ b/src/htr2hpc/train/user_setup.sh
@@ -86,17 +86,10 @@ if { conda env list | grep $conda_env_name; } >/dev/null 2>&1; then
 
 else
 	echo "Creating conda environment $conda_env_name and installing dependencies"
-	mkdir /scratch/network/$USER/setup_htr2hpc
-	cp -r /scratch/network/croughan/htr2hpc_setup/kraken /scratch/network/$USER/setup_htr2hpc
 	conda create -y -n $conda_env_name python=3.11 pip
 	conda activate $conda_env_name
-	# install specifically the pre-downloaded kraken 6.0.4
-	cd /scratch/network/$USER/setup_htr2hpc/kraken
-	pip install .
+	pip install -q kraken==6.0.3
 	pip install -q git+https://github.com/Princeton-CDH/htr2hpc.git@develop#egg=htr2hpc
-	# go back to scratch and delete temp directory
-	cd /scratch/network/$USER
-	rm -rf /scratch/network/$USER/setup_htr2hpc
 fi
 
 htrworkingdir=/scratch/network/$USER/htr2hpc

--- a/src/htr2hpc/train/user_setup.sh
+++ b/src/htr2hpc/train/user_setup.sh
@@ -71,7 +71,7 @@ fi
 
 # create conda environment named htr2hpc
 conda_env_name=htr2hpc
-module load anaconda3/2024.2
+module load anaconda3/2025.6
 if { conda env list | grep $conda_env_name; } >/dev/null 2>&1; then
 	echo "conda env $conda_env_name already exists"
 
@@ -88,12 +88,12 @@ else
 	echo "Creating conda environment $conda_env_name and installing dependencies"
 	mkdir /scratch/network/$USER/setup_htr2hpc
 	cp -r /scratch/network/croughan/htr2hpc_setup/kraken /scratch/network/$USER/setup_htr2hpc
-	cd /scratch/network/$USER/setup_htr2hpc/kraken
-	conda env create -f environment_cuda.yml -n $conda_env_name
+	conda create -y -n $conda_env_name python=3.11 pip
 	conda activate $conda_env_name
+	# install specifically the pre-downloaded kraken 6.0.4
+	cd /scratch/network/$USER/setup_htr2hpc/kraken
+	pip install .
 	pip install -q git+https://github.com/Princeton-CDH/htr2hpc.git@develop#egg=htr2hpc
-	pip install -q torchvision torch==2.1 torchaudio==2.1
-	pip install -q -U "rich<14.1.0"
 	# go back to scratch and delete temp directory
 	cd /scratch/network/$USER
 	rm -rf /scratch/network/$USER/setup_htr2hpc


### PR DESCRIPTION
**Associated Issue(s):** resolves #96 

### Changes in this PR
The old conda install of the kraken 5 version used during the beta test was erroring out, so the previous setup script was failing to create the conda environment and then a separate kraken version was being installed (as a dependency of htr2hpc) in the user's default environment, which caused the torch issues identified in #96 . 

This PR accomplishes the following:

- updates the kraken version used for htr2hpc to 6.0.3
- updates the setup script to use a pip install for kraken -- the conda install method is no longer used for kraken 6 onwards
- updates the slurm code to reorganize arguments (for kraken 6 onwards, certain arguments must go with `ketos` and certain other arguments must go with the following `train`/`segtrain`)

### Notes
When training jobs are run on eScriptorium, the outputs include the below warnings which have not yet been addressed. They do not interfere with the successful training and reimport of models.

```Torch version 2.9.0+cu128 has not been tested with coremltools. You may run into unexpected errors. Torch 2.5.0 is the most recent version that has been tested.
Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLCPUComputeDeviceProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLGPUComputeDeviceProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLNeuralEngineComputeDeviceProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLComputePlanProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLModelProxy: No module named 'coremltools.libcoremlpython'
Failed to load _MLModelAssetProxy: No module named 'coremltools.libcoremlpython'
```

### ChR's Checklist

- [x] Running `user_setup.sh` directly on Adroit successfully sets up the necessary conda environment and directories with no errors
- [x] When deployed to the eScr instance, clicking the "HPC setup" button successfully runs the `user_setup.sh` script, setting up the conda env and directories with no errors.
- [x] When checked, kraken is the correct version (6.0.3)
- [x] When segmentation training jobs are run on eScr after user setup, the training job runs successfully and imports the resulting best model back into eScr
- [x] When transcription training jobs are run on eScr after user setup, the training job runs successfully and imports the resulting best model back into eScr
- [x] Trained models function correctly when run on eScr