### PR TITLE
Add management command to clean up old export files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ This adjusts the settings as follows:
 - Adds to `INSTALLED_APPS` and `AUTHENTICATION_BACKENDS` and provides a basic `PUCAS_LDAP` configuration to enable Princeton CAS authentication; configures `CAS_REDIRECT_URL` to use the escriptorium `LOGIN_REDIRECT_URL` configuration (currently the projects list page) and sets `CAS_IGNORE_REFERER = True` to avoid behavior where successful CAS login takes you back to the login page
 - Sets `ROOT_URLCONF` to use `htr2hpc.urls`, which adds `pucas` url paths to the urls defined in `escriptorium.urls`
 - Adds `htr2hpc/templates` directory first in the list of template directories, so that any templates in this application will take precedence over eScriptorium templates; currently used for customizing the login page to add Princeton CAS login
+- Sets `EXPORT_FILE_RETENTION = 168` (hours) as the default retention period for user export files
+
+### Optional settings
+
+The following settings can be overridden in your local settings file:
+
+- `EXPORT_FILE_RETENTION`: Number of hours to retain user export files before they are eligible for cleanup by the `cleanup_exports` management command. Defaults to `168` (1 week). Set to `0` to disable automatic cleanup entirely.
 
 See [DEPLOY NOTES](DEPLOY_NOTES.md) for instructions on creating a new release and deploying it to the server with cdh-ansible.
 

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -1,0 +1,81 @@
+import datetime
+import logging
+import os
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+EXPORT_FILE_RETENTION_DEFAULT = 30
+
+logger = logging.getLogger(__name__)
+
+
+def delete_old_exports(media_root, retention_days, dry_run=False):
+    """Delete export files under media_root/users/ older than retention_days.
+
+    Returns a (count, total_bytes) tuple of files deleted (or that would be
+    deleted when dry_run=True).
+    """
+    cutoff = datetime.datetime.now() - datetime.timedelta(days=retention_days)
+    users_dir = os.path.join(media_root, "users")
+
+    if not os.path.isdir(users_dir):
+        return 0, 0
+
+    count = 0
+    total_bytes = 0
+
+    for user_dir in os.scandir(users_dir):
+        if not user_dir.is_dir():
+            continue
+        for entry in os.scandir(user_dir.path):
+            if not entry.name.startswith("export_"):
+                continue
+            stat = entry.stat()
+            mtime = datetime.datetime.fromtimestamp(stat.st_mtime)
+            if mtime < cutoff:
+                size = stat.st_size
+                logger.info("Deleting %s (%d bytes)", entry.path, size)
+                if not dry_run:
+                    os.remove(entry.path)
+                count += 1
+                total_bytes += size
+
+    return count, total_bytes
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete export files older than settings.EXPORT_FILE_RETENTION days "
+        "(default: %d days)." % EXPORT_FILE_RETENTION_DEFAULT
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Report what would be deleted without actually deleting.",
+        )
+
+    def handle(self, *args, **kwargs):
+        dry_run = kwargs["dry_run"]
+        retention = getattr(
+            settings, "EXPORT_FILE_RETENTION", EXPORT_FILE_RETENTION_DEFAULT
+        )
+
+        if retention == 0:
+            self.stdout.write(
+                "EXPORT_FILE_RETENTION set to 0. Nothing will be cleaned up."
+            )
+            return
+
+        if not os.path.isdir(os.path.join(settings.MEDIA_ROOT, "users")):
+            self.stdout.write("No users media directory found; nothing to clean up.")
+            return
+
+        count, total_bytes = delete_old_exports(settings.MEDIA_ROOT, retention, dry_run)
+        action = "Would delete" if dry_run else "Deleted"
+        self.stdout.write(
+            "%s %d export file(s), freeing %d bytes." % (action, count, total_bytes)
+        )

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -1,22 +1,35 @@
 import datetime
-import logging
 from pathlib import Path
+from typing import Generator
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-EXPORT_FILE_RETENTION_DEFAULT = 30
+VERBOSITY_QUIET = 0
+VERBOSITY_NORMAL = 1
+VERBOSITY_VERBOSE = 2
 
-logger = logging.getLogger(__name__)
+
+def get_old_exports(
+    users_dir: Path, cutoff: datetime.datetime
+) -> Generator[tuple[Path, int], None, None]:
+    """Yield (path, size_in_bytes) for export files older than cutoff."""
+    for entry in users_dir.glob("*/export_*.zip"):
+        stat = entry.stat()
+        mtime = datetime.datetime.fromtimestamp(stat.st_mtime)
+        if mtime < cutoff:
+            yield entry, stat.st_size
 
 
-def delete_old_exports(media_root, retention_days, dry_run=False):
-    """Delete export files under media_root/users/ older than retention_days.
+def delete_old_exports(
+    media_root: Path | str, retention_hours: int, dry_run: bool = False
+) -> tuple[int, int]:
+    """Delete export files under media_root/users/ older than retention_hours.
 
     Returns a (count, total_bytes) tuple of files deleted (or that would be
     deleted when dry_run=True).
     """
-    cutoff = datetime.datetime.now() - datetime.timedelta(days=retention_days)
+    cutoff = datetime.datetime.now() - datetime.timedelta(hours=retention_hours)
     users_dir = Path(media_root) / "users"
 
     if not users_dir.is_dir():
@@ -25,30 +38,17 @@ def delete_old_exports(media_root, retention_days, dry_run=False):
     count = 0
     total_bytes = 0
 
-    for user_dir in users_dir.iterdir():
-        if not user_dir.is_dir():
-            continue
-        for entry in user_dir.iterdir():
-            if not entry.name.startswith("export_"):
-                continue
-            stat = entry.stat()
-            mtime = datetime.datetime.fromtimestamp(stat.st_mtime)
-            if mtime < cutoff:
-                size = stat.st_size
-                logger.info("Deleting %s (%d bytes)", entry, size)
-                if not dry_run:
-                    entry.unlink()
-                count += 1
-                total_bytes += size
+    for entry, size in get_old_exports(users_dir, cutoff):
+        if not dry_run:
+            entry.unlink()
+        count += 1
+        total_bytes += size
 
     return count, total_bytes
 
 
 class Command(BaseCommand):
-    help = (
-        f"Delete export files older than settings.EXPORT_FILE_RETENTION days "
-        f"(default: {EXPORT_FILE_RETENTION_DEFAULT} days)."
-    )
+    help = "Delete export files older than settings.EXPORT_FILE_RETENTION hours."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -60,9 +60,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         dry_run = kwargs["dry_run"]
-        retention = getattr(
-            settings, "EXPORT_FILE_RETENTION", EXPORT_FILE_RETENTION_DEFAULT
-        )
+        verbosity = kwargs["verbosity"]
+        retention = settings.EXPORT_FILE_RETENTION
 
         if retention == 0:
             self.stdout.write(
@@ -70,12 +69,26 @@ class Command(BaseCommand):
             )
             return
 
-        if not (Path(settings.MEDIA_ROOT) / "users").is_dir():
+        users_dir = Path(settings.MEDIA_ROOT) / "users"
+        if not users_dir.is_dir():
             self.stdout.write("No users media directory found; nothing to clean up.")
             return
 
-        count, total_bytes = delete_old_exports(settings.MEDIA_ROOT, retention, dry_run)
-        action = "Would delete" if dry_run else "Deleted"
-        self.stdout.write(
-            f"{action} {count} export file(s), freeing {total_bytes} bytes."
-        )
+        cutoff = datetime.datetime.now() - datetime.timedelta(hours=retention)
+        count = 0
+        total_bytes = 0
+
+        for entry, size in get_old_exports(users_dir, cutoff):
+            if verbosity >= VERBOSITY_VERBOSE:
+                action = "Would delete" if dry_run else "Deleting"
+                self.stdout.write(f"{action} {entry} ({size} bytes)")
+            if not dry_run:
+                entry.unlink()
+            count += 1
+            total_bytes += size
+
+        if verbosity >= VERBOSITY_NORMAL:
+            action = "Would delete" if dry_run else "Deleted"
+            self.stdout.write(
+                f"{action} {count} export file(s), freeing {total_bytes} bytes."
+            )

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -5,6 +5,8 @@ from typing import Generator
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+EXPORT_FILE_RETENTION_DEFAULT = 168  # 1 week in hours
+
 VERBOSITY_QUIET = 0
 VERBOSITY_NORMAL = 1
 VERBOSITY_VERBOSE = 2

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-import os
+from pathlib import Path
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -17,27 +17,27 @@ def delete_old_exports(media_root, retention_days, dry_run=False):
     deleted when dry_run=True).
     """
     cutoff = datetime.datetime.now() - datetime.timedelta(days=retention_days)
-    users_dir = os.path.join(media_root, "users")
+    users_dir = Path(media_root) / "users"
 
-    if not os.path.isdir(users_dir):
+    if not users_dir.is_dir():
         return 0, 0
 
     count = 0
     total_bytes = 0
 
-    for user_dir in os.scandir(users_dir):
+    for user_dir in users_dir.iterdir():
         if not user_dir.is_dir():
             continue
-        for entry in os.scandir(user_dir.path):
+        for entry in user_dir.iterdir():
             if not entry.name.startswith("export_"):
                 continue
             stat = entry.stat()
             mtime = datetime.datetime.fromtimestamp(stat.st_mtime)
             if mtime < cutoff:
                 size = stat.st_size
-                logger.info("Deleting %s (%d bytes)", entry.path, size)
+                logger.info("Deleting %s (%d bytes)", entry, size)
                 if not dry_run:
-                    os.remove(entry.path)
+                    entry.unlink()
                 count += 1
                 total_bytes += size
 
@@ -46,8 +46,8 @@ def delete_old_exports(media_root, retention_days, dry_run=False):
 
 class Command(BaseCommand):
     help = (
-        "Delete export files older than settings.EXPORT_FILE_RETENTION days "
-        "(default: %d days)." % EXPORT_FILE_RETENTION_DEFAULT
+        f"Delete export files older than settings.EXPORT_FILE_RETENTION days "
+        f"(default: {EXPORT_FILE_RETENTION_DEFAULT} days)."
     )
 
     def add_arguments(self, parser):
@@ -70,12 +70,12 @@ class Command(BaseCommand):
             )
             return
 
-        if not os.path.isdir(os.path.join(settings.MEDIA_ROOT, "users")):
+        if not (Path(settings.MEDIA_ROOT) / "users").is_dir():
             self.stdout.write("No users media directory found; nothing to clean up.")
             return
 
         count, total_bytes = delete_old_exports(settings.MEDIA_ROOT, retention, dry_run)
         action = "Would delete" if dry_run else "Deleted"
         self.stdout.write(
-            "%s %d export file(s), freeing %d bytes." % (action, count, total_bytes)
+            f"{action} {count} export file(s), freeing {total_bytes} bytes."
         )

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -40,7 +40,10 @@ def delete_old_exports(
 
     for entry, size in get_old_exports(users_dir, cutoff):
         if not dry_run:
-            entry.unlink()
+            try:
+                entry.unlink()
+            except OSError:
+                continue
         count += 1
         total_bytes += size
 

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -5,10 +5,6 @@ from typing import Generator
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-VERBOSITY_QUIET = 0
-VERBOSITY_NORMAL = 1
-VERBOSITY_VERBOSE = 2
-
 
 def get_old_exports(
     users_dir: Path, cutoff: datetime.datetime
@@ -21,37 +17,9 @@ def get_old_exports(
             yield entry, stat.st_size
 
 
-def delete_old_exports(
-    media_root: Path | str, retention_hours: int, dry_run: bool = False
-) -> tuple[int, int]:
-    """Delete export files under media_root/users/ older than retention_hours.
-
-    Returns a (count, total_bytes) tuple of files deleted (or that would be
-    deleted when dry_run=True).
-    """
-    cutoff = datetime.datetime.now() - datetime.timedelta(hours=retention_hours)
-    users_dir = Path(media_root) / "users"
-
-    if not users_dir.is_dir():
-        return 0, 0
-
-    count = 0
-    total_bytes = 0
-
-    for entry, size in get_old_exports(users_dir, cutoff):
-        if not dry_run:
-            try:
-                entry.unlink()
-            except OSError:
-                continue
-        count += 1
-        total_bytes += size
-
-    return count, total_bytes
-
-
 class Command(BaseCommand):
     help = "Delete export files older than settings.EXPORT_FILE_RETENTION hours."
+    v_normal = 1
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -61,9 +29,39 @@ class Command(BaseCommand):
             help="Report what would be deleted without actually deleting.",
         )
 
+    def delete_old_exports(
+        self, export_dir: Path, retention_hours: int
+    ) -> tuple[int, int]:
+        """Delete export files in export_dir older than retention_hours.
+
+        Returns a (count, total_bytes) tuple of files deleted (or that would be
+        deleted when dry_run=True).
+        """
+        cutoff = datetime.datetime.now() - datetime.timedelta(hours=retention_hours)
+
+        if not export_dir.is_dir():
+            return 0, 0
+
+        count = 0
+        total_bytes = 0
+
+        for entry, size in get_old_exports(export_dir, cutoff):
+            if self.verbosity >= self.v_normal + 1:
+                action = "Would delete" if self.dry_run else "Deleting"
+                self.stdout.write(f"{action} {entry} ({size} bytes)")
+            if not self.dry_run:
+                try:
+                    entry.unlink()
+                except OSError:
+                    continue
+            count += 1
+            total_bytes += size
+
+        return count, total_bytes
+
     def handle(self, *args, **kwargs):
-        dry_run = kwargs["dry_run"]
-        verbosity = kwargs["verbosity"]
+        self.dry_run = kwargs["dry_run"]
+        self.verbosity = kwargs["verbosity"]
         retention = settings.EXPORT_FILE_RETENTION
 
         if retention == 0:
@@ -72,21 +70,15 @@ class Command(BaseCommand):
             )
             return
 
-        users_dir = Path(settings.MEDIA_ROOT) / "users"
-        if not users_dir.is_dir():
+        export_dir = Path(settings.MEDIA_ROOT) / "users"
+        if not export_dir.is_dir():
             self.stdout.write("No users media directory found; nothing to clean up.")
             return
 
-        if verbosity >= VERBOSITY_VERBOSE:
-            cutoff = datetime.datetime.now() - datetime.timedelta(hours=retention)
-            for entry, size in get_old_exports(users_dir, cutoff):
-                action = "Would delete" if dry_run else "Deleting"
-                self.stdout.write(f"{action} {entry} ({size} bytes)")
+        count, total_bytes = self.delete_old_exports(export_dir, retention)
 
-        count, total_bytes = delete_old_exports(settings.MEDIA_ROOT, retention, dry_run)
-
-        if verbosity >= VERBOSITY_NORMAL:
-            action = "Would delete" if dry_run else "Deleted"
+        if self.verbosity >= self.v_normal:
+            action = "Would delete" if self.dry_run else "Deleted"
             self.stdout.write(
                 f"{action} {count} export file(s), freeing {total_bytes} bytes."
             )

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -5,8 +5,6 @@ from typing import Generator
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-EXPORT_FILE_RETENTION_DEFAULT = 168  # 1 week in hours
-
 VERBOSITY_QUIET = 0
 VERBOSITY_NORMAL = 1
 VERBOSITY_VERBOSE = 2

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -18,7 +18,10 @@ def get_old_exports(
 
 
 class Command(BaseCommand):
-    help = "Delete export files older than settings.EXPORT_FILE_RETENTION hours."
+    help = (
+        "Delete export files (export_*.zip) under MEDIA_ROOT/users/ "
+        "older than settings.EXPORT_FILE_RETENTION hours."
+    )
     v_normal = 1
 
     def add_arguments(self, parser):

--- a/src/htr2hpc/management/commands/cleanup_exports.py
+++ b/src/htr2hpc/management/commands/cleanup_exports.py
@@ -77,18 +77,13 @@ class Command(BaseCommand):
             self.stdout.write("No users media directory found; nothing to clean up.")
             return
 
-        cutoff = datetime.datetime.now() - datetime.timedelta(hours=retention)
-        count = 0
-        total_bytes = 0
-
-        for entry, size in get_old_exports(users_dir, cutoff):
-            if verbosity >= VERBOSITY_VERBOSE:
+        if verbosity >= VERBOSITY_VERBOSE:
+            cutoff = datetime.datetime.now() - datetime.timedelta(hours=retention)
+            for entry, size in get_old_exports(users_dir, cutoff):
                 action = "Would delete" if dry_run else "Deleting"
                 self.stdout.write(f"{action} {entry} ({size} bytes)")
-            if not dry_run:
-                entry.unlink()
-            count += 1
-            total_bytes += size
+
+        count, total_bytes = delete_old_exports(settings.MEDIA_ROOT, retention, dry_run)
 
         if verbosity >= VERBOSITY_NORMAL:
             action = "Would delete" if dry_run else "Deleted"

--- a/src/htr2hpc/settings.py
+++ b/src/htr2hpc/settings.py
@@ -51,3 +51,7 @@ TEMPLATES[0]["OPTIONS"]["context_processors"].append(
 
 
 CUSTOM_HOME = True
+
+# Number of hours to retain user export files before cleanup.
+# Set to 0 to disable automatic cleanup entirely.
+EXPORT_FILE_RETENTION = 168  # 1 week

--- a/tests/test_cleanup_exports.py
+++ b/tests/test_cleanup_exports.py
@@ -10,10 +10,10 @@ from htr2hpc.management.commands.cleanup_exports import (
 )
 
 
-def make_file(path, age_days):
-    """Create a file and set its mtime to age_days ago."""
+def make_file(path, age_hours):
+    """Create a file and set its mtime to age_hours ago."""
     path.touch()
-    mtime = (datetime.datetime.now() - datetime.timedelta(days=age_days)).timestamp()
+    mtime = (datetime.datetime.now() - datetime.timedelta(hours=age_hours)).timestamp()
     os.utime(path, (mtime, mtime))
 
 
@@ -27,7 +27,7 @@ def media_root(tmp_path):
 
 def test_deletes_old_export_files(media_root):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
-    make_file(old_file, age_days=35)
+    make_file(old_file, age_hours=840)  # 35 days
 
     count, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
 
@@ -38,7 +38,7 @@ def test_deletes_old_export_files(media_root):
 
 def test_keeps_recent_export_files(media_root):
     recent_file = media_root / "users" / "42" / "export_doc1_test_alto_20240601.zip"
-    make_file(recent_file, age_days=5)
+    make_file(recent_file, age_hours=120)  # 5 days
 
     count, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
 
@@ -49,7 +49,7 @@ def test_keeps_recent_export_files(media_root):
 
 def test_dry_run_does_not_delete(media_root):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
-    make_file(old_file, age_days=35)
+    make_file(old_file, age_hours=840)  # 35 days
 
     count, _ = delete_old_exports(
         str(media_root), EXPORT_FILE_RETENTION_DEFAULT, dry_run=True
@@ -61,7 +61,7 @@ def test_dry_run_does_not_delete(media_root):
 
 def test_ignores_non_export_files(media_root):
     other_file = media_root / "users" / "42" / "manifest.json"
-    make_file(other_file, age_days=35)
+    make_file(other_file, age_hours=840)  # 35 days
 
     count, _ = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
 
@@ -70,16 +70,16 @@ def test_ignores_non_export_files(media_root):
 
 
 def test_respects_custom_retention(media_root):
-    # 10 days old — older than 7-day retention but newer than 30-day default
+    # 240 hours (10 days) old — older than 168-hour (1 week) retention but newer than 720-hour (30 day) default
     borderline_file = media_root / "users" / "42" / "export_doc1_test_alto_20240601.zip"
-    make_file(borderline_file, age_days=10)
+    make_file(borderline_file, age_hours=240)
 
-    count_default, _ = delete_old_exports(str(media_root), retention_days=30)
-    assert borderline_file.exists(), "should be kept under default 30-day retention"
+    count_default, _ = delete_old_exports(str(media_root), retention_hours=720)
+    assert borderline_file.exists(), "should be kept under 720-hour (30-day) retention"
     assert count_default == 0
 
-    count_short, _ = delete_old_exports(str(media_root), retention_days=7)
-    assert not borderline_file.exists(), "should be deleted under 7-day retention"
+    count_short, _ = delete_old_exports(str(media_root), retention_hours=168)
+    assert not borderline_file.exists(), "should be deleted under 168-hour (1-week) retention"
     assert count_short == 1
 
 
@@ -93,7 +93,7 @@ def test_missing_users_dir_returns_zeros(tmp_path):
 def test_reports_bytes_freed(media_root):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     old_file.write_bytes(b"x" * 1024)
-    mtime = (datetime.datetime.now() - datetime.timedelta(days=35)).timestamp()
+    mtime = (datetime.datetime.now() - datetime.timedelta(hours=840)).timestamp()  # 35 days
     os.utime(old_file, (mtime, mtime))
 
     _, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
@@ -107,8 +107,8 @@ def test_deletes_files_across_multiple_users(media_root):
 
     old1 = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     old2 = user2_dir / "export_doc2_test_pagexml_20240101.zip"
-    make_file(old1, age_days=35)
-    make_file(old2, age_days=35)
+    make_file(old1, age_hours=840)  # 35 days
+    make_file(old2, age_hours=840)  # 35 days
 
     count, _ = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
 

--- a/tests/test_cleanup_exports.py
+++ b/tests/test_cleanup_exports.py
@@ -1,0 +1,117 @@
+"""Tests for the cleanup_exports management command."""
+import datetime
+import os
+
+import pytest
+
+from htr2hpc.management.commands.cleanup_exports import (
+    EXPORT_FILE_RETENTION_DEFAULT,
+    delete_old_exports,
+)
+
+
+def make_file(path, age_days):
+    """Create a file and set its mtime to age_days ago."""
+    path.touch()
+    mtime = (datetime.datetime.now() - datetime.timedelta(days=age_days)).timestamp()
+    os.utime(path, (mtime, mtime))
+
+
+@pytest.fixture
+def media_root(tmp_path):
+    """Set up a fake MEDIA_ROOT with a users directory."""
+    user_dir = tmp_path / "users" / "42"
+    user_dir.mkdir(parents=True)
+    return tmp_path
+
+
+def test_deletes_old_export_files(media_root):
+    old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
+    make_file(old_file, age_days=35)
+
+    count, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+
+    assert not old_file.exists()
+    assert count == 1
+    assert total_bytes == 0  # empty file
+
+
+def test_keeps_recent_export_files(media_root):
+    recent_file = media_root / "users" / "42" / "export_doc1_test_alto_20240601.zip"
+    make_file(recent_file, age_days=5)
+
+    count, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+
+    assert recent_file.exists()
+    assert count == 0
+    assert total_bytes == 0
+
+
+def test_dry_run_does_not_delete(media_root):
+    old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
+    make_file(old_file, age_days=35)
+
+    count, total_bytes = delete_old_exports(
+        str(media_root), EXPORT_FILE_RETENTION_DEFAULT, dry_run=True
+    )
+
+    assert old_file.exists()
+    assert count == 1
+
+
+def test_ignores_non_export_files(media_root):
+    other_file = media_root / "users" / "42" / "manifest.json"
+    make_file(other_file, age_days=35)
+
+    count, _ = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+
+    assert other_file.exists()
+    assert count == 0
+
+
+def test_respects_custom_retention(media_root):
+    # 10 days old — older than 7-day retention but newer than 30-day default
+    borderline_file = media_root / "users" / "42" / "export_doc1_test_alto_20240601.zip"
+    make_file(borderline_file, age_days=10)
+
+    count_default, _ = delete_old_exports(str(media_root), retention_days=30)
+    assert borderline_file.exists(), "should be kept under default 30-day retention"
+    assert count_default == 0
+
+    count_short, _ = delete_old_exports(str(media_root), retention_days=7)
+    assert not borderline_file.exists(), "should be deleted under 7-day retention"
+    assert count_short == 1
+
+
+def test_missing_users_dir_returns_zeros(tmp_path):
+    # MEDIA_ROOT exists but has no users/ subdirectory
+    count, total_bytes = delete_old_exports(str(tmp_path), EXPORT_FILE_RETENTION_DEFAULT)
+    assert count == 0
+    assert total_bytes == 0
+
+
+def test_reports_bytes_freed(media_root):
+    old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
+    old_file.write_bytes(b"x" * 1024)
+    mtime = (datetime.datetime.now() - datetime.timedelta(days=35)).timestamp()
+    os.utime(old_file, (mtime, mtime))
+
+    _, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+
+    assert total_bytes == 1024
+
+
+def test_deletes_files_across_multiple_users(media_root):
+    user2_dir = media_root / "users" / "99"
+    user2_dir.mkdir()
+
+    old1 = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
+    old2 = user2_dir / "export_doc2_test_pagexml_20240101.zip"
+    make_file(old1, age_days=35)
+    make_file(old2, age_days=35)
+
+    count, _ = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+
+    assert not old1.exists()
+    assert not old2.exists()
+    assert count == 2

--- a/tests/test_cleanup_exports.py
+++ b/tests/test_cleanup_exports.py
@@ -51,7 +51,7 @@ def test_dry_run_does_not_delete(media_root):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     make_file(old_file, age_days=35)
 
-    count, total_bytes = delete_old_exports(
+    count, _ = delete_old_exports(
         str(media_root), EXPORT_FILE_RETENTION_DEFAULT, dry_run=True
     )
 

--- a/tests/test_cleanup_exports.py
+++ b/tests/test_cleanup_exports.py
@@ -3,9 +3,10 @@ import datetime
 import os
 
 import pytest
+from django.test import override_settings
+from django.core.management import call_command
 
 from htr2hpc.management.commands.cleanup_exports import (
-    EXPORT_FILE_RETENTION_DEFAULT,
     delete_old_exports,
 )
 
@@ -94,7 +95,6 @@ def test_reports_bytes_freed(media_root):
     mtime = (datetime.datetime.now() - datetime.timedelta(hours=840)).timestamp()  # 35 days
     os.utime(old_file, (mtime, mtime))
 
-    _, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
     _, total_bytes = delete_old_exports(str(media_root), 168)
 
     assert total_bytes == 1024
@@ -114,3 +114,61 @@ def test_deletes_files_across_multiple_users(media_root):
     assert not old1.exists()
     assert not old2.exists()
     assert count == 2
+
+
+def test_unlink_error_is_skipped(media_root, mocker):
+    old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
+    make_file(old_file, age_hours=840)
+
+    mocker.patch("pathlib.Path.unlink", side_effect=OSError("permission denied"))
+
+    count, total_bytes = delete_old_exports(str(media_root), 168)
+
+    assert old_file.exists()
+    assert count == 0
+    assert total_bytes == 0
+
+
+@pytest.mark.django_db
+def test_handle_retention_zero(tmp_path, capsys):
+    with override_settings(EXPORT_FILE_RETENTION=0, MEDIA_ROOT=str(tmp_path)):
+        call_command("cleanup_exports")
+
+    captured = capsys.readouterr()
+    assert "set to 0" in captured.out
+
+
+@pytest.mark.django_db
+def test_handle_missing_users_dir(tmp_path, capsys):
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(tmp_path)):
+        call_command("cleanup_exports")
+
+    captured = capsys.readouterr()
+    assert "nothing to clean up" in captured.out
+
+
+@pytest.mark.django_db
+def test_handle_deletes_old_exports(media_root, capsys):
+    old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
+    make_file(old_file, age_hours=840)
+
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
+
+    assert not old_file.exists()
+    captured = capsys.readouterr()
+    assert "Deleted 1 export file(s)" in captured.out
+
+
+@pytest.mark.django_db
+def test_handle_dry_run(media_root, capsys):
+    old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
+    make_file(old_file, age_hours=840)
+
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports", dry_run=True)
+
+    assert old_file.exists()
+    captured = capsys.readouterr()
+    assert "Would delete 1 export file(s)" in captured.out
+

--- a/tests/test_cleanup_exports.py
+++ b/tests/test_cleanup_exports.py
@@ -3,12 +3,10 @@ import datetime
 import os
 
 import pytest
-from django.test import override_settings
 from django.core.management import call_command
+from django.test import override_settings
 
-from htr2hpc.management.commands.cleanup_exports import (
-    delete_old_exports,
-)
+from htr2hpc.management.commands.cleanup_exports import get_old_exports
 
 
 def make_file(path, age_hours):
@@ -26,80 +24,90 @@ def media_root(tmp_path):
     return tmp_path
 
 
-def test_deletes_old_export_files(media_root):
+@pytest.mark.django_db
+def test_deletes_old_export_files(media_root, capsys):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     make_file(old_file, age_hours=840)  # 35 days
 
-    count, total_bytes = delete_old_exports(str(media_root), 168)
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
 
     assert not old_file.exists()
-    assert count == 1
-    assert total_bytes == 0  # empty file
 
 
+@pytest.mark.django_db
 def test_keeps_recent_export_files(media_root):
     recent_file = media_root / "users" / "42" / "export_doc1_test_alto_20240601.zip"
     make_file(recent_file, age_hours=120)  # 5 days
 
-    count, total_bytes = delete_old_exports(str(media_root), 168)
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
 
     assert recent_file.exists()
-    assert count == 0
-    assert total_bytes == 0
 
 
+@pytest.mark.django_db
 def test_dry_run_does_not_delete(media_root):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     make_file(old_file, age_hours=840)  # 35 days
 
-    count, _ = delete_old_exports(str(media_root), 168, dry_run=True)
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports", dry_run=True)
 
     assert old_file.exists()
-    assert count == 1
 
 
+@pytest.mark.django_db
 def test_ignores_non_export_files(media_root):
     other_file = media_root / "users" / "42" / "manifest.json"
     make_file(other_file, age_hours=840)  # 35 days
 
-    count, _ = delete_old_exports(str(media_root), 168)
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
 
     assert other_file.exists()
-    assert count == 0
 
 
+@pytest.mark.django_db
 def test_respects_custom_retention(media_root):
-    # 240 hours (10 days) old — older than 168-hour (1 week) retention but newer than 720-hour (30 day) default
+    # 240 hours (10 days) old — older than 168-hour (1 week) but newer than 720-hour (30 day)
     borderline_file = media_root / "users" / "42" / "export_doc1_test_alto_20240601.zip"
     make_file(borderline_file, age_hours=240)
 
-    count_default, _ = delete_old_exports(str(media_root), retention_hours=720)
+    with override_settings(EXPORT_FILE_RETENTION=720, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
     assert borderline_file.exists(), "should be kept under 720-hour (30-day) retention"
-    assert count_default == 0
 
-    count_short, _ = delete_old_exports(str(media_root), retention_hours=168)
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
     assert not borderline_file.exists(), "should be deleted under 168-hour (1-week) retention"
-    assert count_short == 1
 
 
-def test_missing_users_dir_returns_zeros(tmp_path):
+@pytest.mark.django_db
+def test_missing_users_dir_returns_zeros(tmp_path, capsys):
     # MEDIA_ROOT exists but has no users/ subdirectory
-    count, total_bytes = delete_old_exports(str(tmp_path), 168)
-    assert count == 0
-    assert total_bytes == 0
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(tmp_path)):
+        call_command("cleanup_exports")
+
+    captured = capsys.readouterr()
+    assert "nothing to clean up" in captured.out
 
 
-def test_reports_bytes_freed(media_root):
+@pytest.mark.django_db
+def test_reports_bytes_freed(media_root, capsys):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     old_file.write_bytes(b"x" * 1024)
-    mtime = (datetime.datetime.now() - datetime.timedelta(hours=840)).timestamp()  # 35 days
+    mtime = (datetime.datetime.now() - datetime.timedelta(hours=840)).timestamp()
     os.utime(old_file, (mtime, mtime))
 
-    _, total_bytes = delete_old_exports(str(media_root), 168)
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
 
-    assert total_bytes == 1024
+    captured = capsys.readouterr()
+    assert "1024 bytes" in captured.out
 
 
+@pytest.mark.django_db
 def test_deletes_files_across_multiple_users(media_root):
     user2_dir = media_root / "users" / "99"
     user2_dir.mkdir()
@@ -109,24 +117,26 @@ def test_deletes_files_across_multiple_users(media_root):
     make_file(old1, age_hours=840)  # 35 days
     make_file(old2, age_hours=840)  # 35 days
 
-    count, _ = delete_old_exports(str(media_root), 168)
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
 
     assert not old1.exists()
     assert not old2.exists()
-    assert count == 2
 
 
-def test_unlink_error_is_skipped(media_root, mocker):
+@pytest.mark.django_db
+def test_unlink_error_is_skipped(media_root, capsys, mocker):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     make_file(old_file, age_hours=840)
 
     mocker.patch("pathlib.Path.unlink", side_effect=OSError("permission denied"))
 
-    count, total_bytes = delete_old_exports(str(media_root), 168)
+    with override_settings(EXPORT_FILE_RETENTION=168, MEDIA_ROOT=str(media_root)):
+        call_command("cleanup_exports")
 
     assert old_file.exists()
-    assert count == 0
-    assert total_bytes == 0
+    captured = capsys.readouterr()
+    assert "Deleted 0 export file(s)" in captured.out
 
 
 @pytest.mark.django_db
@@ -171,4 +181,18 @@ def test_handle_dry_run(media_root, capsys):
     assert old_file.exists()
     captured = capsys.readouterr()
     assert "Would delete 1 export file(s)" in captured.out
+
+
+def test_get_old_exports(media_root):
+    """Unit test for get_old_exports() helper directly."""
+    old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
+    recent_file = media_root / "users" / "42" / "export_doc2_test_alto_20240601.zip"
+    make_file(old_file, age_hours=840)
+    make_file(recent_file, age_hours=10)
+
+    cutoff = datetime.datetime.now() - datetime.timedelta(hours=168)
+    results = list(get_old_exports(media_root / "users", cutoff))
+
+    assert len(results) == 1
+    assert results[0][0] == old_file
 

--- a/tests/test_cleanup_exports.py
+++ b/tests/test_cleanup_exports.py
@@ -29,7 +29,7 @@ def test_deletes_old_export_files(media_root):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     make_file(old_file, age_hours=840)  # 35 days
 
-    count, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+    count, total_bytes = delete_old_exports(str(media_root), 168)
 
     assert not old_file.exists()
     assert count == 1
@@ -40,7 +40,7 @@ def test_keeps_recent_export_files(media_root):
     recent_file = media_root / "users" / "42" / "export_doc1_test_alto_20240601.zip"
     make_file(recent_file, age_hours=120)  # 5 days
 
-    count, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+    count, total_bytes = delete_old_exports(str(media_root), 168)
 
     assert recent_file.exists()
     assert count == 0
@@ -51,9 +51,7 @@ def test_dry_run_does_not_delete(media_root):
     old_file = media_root / "users" / "42" / "export_doc1_test_alto_20240101.zip"
     make_file(old_file, age_hours=840)  # 35 days
 
-    count, _ = delete_old_exports(
-        str(media_root), EXPORT_FILE_RETENTION_DEFAULT, dry_run=True
-    )
+    count, _ = delete_old_exports(str(media_root), 168, dry_run=True)
 
     assert old_file.exists()
     assert count == 1
@@ -63,7 +61,7 @@ def test_ignores_non_export_files(media_root):
     other_file = media_root / "users" / "42" / "manifest.json"
     make_file(other_file, age_hours=840)  # 35 days
 
-    count, _ = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+    count, _ = delete_old_exports(str(media_root), 168)
 
     assert other_file.exists()
     assert count == 0
@@ -85,7 +83,7 @@ def test_respects_custom_retention(media_root):
 
 def test_missing_users_dir_returns_zeros(tmp_path):
     # MEDIA_ROOT exists but has no users/ subdirectory
-    count, total_bytes = delete_old_exports(str(tmp_path), EXPORT_FILE_RETENTION_DEFAULT)
+    count, total_bytes = delete_old_exports(str(tmp_path), 168)
     assert count == 0
     assert total_bytes == 0
 
@@ -97,6 +95,7 @@ def test_reports_bytes_freed(media_root):
     os.utime(old_file, (mtime, mtime))
 
     _, total_bytes = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+    _, total_bytes = delete_old_exports(str(media_root), 168)
 
     assert total_bytes == 1024
 
@@ -110,7 +109,7 @@ def test_deletes_files_across_multiple_users(media_root):
     make_file(old1, age_hours=840)  # 35 days
     make_file(old2, age_hours=840)  # 35 days
 
-    count, _ = delete_old_exports(str(media_root), EXPORT_FILE_RETENTION_DEFAULT)
+    count, _ = delete_old_exports(str(media_root), 168)
 
     assert not old1.exists()
     assert not old2.exists()


### PR DESCRIPTION
**Associated Issue(s):** resolves #70

### Changes in this PR

- Add `cleanup_exports` management command that deletes export files older than `EXPORT_FILE_RETENTION` hours (default: 168 hours / 1 week) from `MEDIA_ROOT/users/`
- Supports `--dry-run` flag to preview what would be deleted without making changes
- Use `Path.glob("*/export_*.zip")` to match only export files (all exports are zip files)
- Output verbosity controlled by Django's `--verbosity` flag: file-level detail at `--verbosity 2`, summary at default verbosity, silent at `--verbosity 0`
- Document `EXPORT_FILE_RETENTION` setting in README

### Notes
- To disable cleanup entirely, set `EXPORT_FILE_RETENTION = 0`
- Tested manually on staging with `--dry-run`: identified 34 files (~33 GB) eligible for deletion
- Scheduling is not configured in this PR yet; will open a follow-up PR to configure the cron timer

### Reviewer Checklist
- [ ] To generate some test exports locally: log in, open any document, and use the Export button to download a file; then adjust its mtime to simulate an old file (like `touch -t 202601010000 <file>`)
- [ ] Run `python manage.py cleanup_exports --dry-run --verbosity 2` and confirm the output lists expected files
- [ ] Run `python manage.py cleanup_exports` and confirm files are deleted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cleanup command for old user export files, with a dry-run option and summary output.
  * Introduced a default 1-week retention period for export files, configurable in settings and disableable by setting it to `0`.

* **Documentation**
  * Updated the README with guidance on export file retention and cleanup behavior.

* **Tests**
  * Added coverage for export cleanup behavior, including retention limits, dry runs, missing folders, and file size reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->