### PR TITLE
Fix/update ssh key label

### DIFF
--- a/src/htr2hpc/train/user_setup.sh
+++ b/src/htr2hpc/train/user_setup.sh
@@ -41,7 +41,7 @@ if $ssh_setup; then
 	fi
 
 	# add htr2hpc public key to authorized keys if not already present (same key used for staging and production)
-	ssh_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJzoR8jstrofzFKVoiXSFP5jGw/WbXHxFyIaS5b4vSWC htr2hpc'
+	ssh_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJzoR8jstrofzFKVoiXSFP5jGw/WbXHxFyIaS5b4vSWC htr.cdh.princeton.edu'
 	if ! grep -q "$ssh_key" $HOME/.ssh/authorized_keys; then
 	    echo "Adding htr2hpc ssh key to authorized keys"
 	    echo $ssh_key >> ~/.ssh/authorized_keys

--- a/src/htr2hpc/train/user_setup.sh
+++ b/src/htr2hpc/train/user_setup.sh
@@ -40,8 +40,8 @@ if $ssh_setup; then
 	    mkdir ~/.ssh
 	fi
 
-	# add test-htr public key to authorized keys if not already present
-	ssh_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJzoR8jstrofzFKVoiXSFP5jGw/WbXHxFyIaS5b4vSWC test-htr.lib.princeton.edu'
+	# add htr2hpc public key to authorized keys if not already present (same key used for staging and production)
+	ssh_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJzoR8jstrofzFKVoiXSFP5jGw/WbXHxFyIaS5b4vSWC htr2hpc'
 	if ! grep -q "$ssh_key" $HOME/.ssh/authorized_keys; then
 	    echo "Adding htr2hpc ssh key to authorized keys"
 	    echo $ssh_key >> ~/.ssh/authorized_keys


### PR DESCRIPTION
**Associated Issue(s):** resolves #95

### Changes in this PR

- Update SSH key label from `test-htr.lib.princeton.edu` to the production url `htr.cdh.princeton.edu`
- Update comment to note that the same key is used for both staging and production

### Notes

### Reviewer Checklist

- [ ] Confirm the label name is good